### PR TITLE
Fix import issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@
 build/
 install/
 dist/
-AvAtom.egg-info/
+atoMEC.egg-info/
 
 # data / results files
 *.csv

--- a/atoMEC/__init__.py
+++ b/atoMEC/__init__.py
@@ -5,10 +5,10 @@ from math import pi
 import mendeleev
 
 # global imports
-import config
-import check_inputs
-from models import *
-import writeoutput
+from . import config
+from . import check_inputs
+from .models import *
+from . import writeoutput
 
 
 class Atom:

--- a/atoMEC/check_inputs.py
+++ b/atoMEC/check_inputs.py
@@ -12,9 +12,9 @@ import numpy as np
 from math import pi
 
 # internal packages
-import unitconv
-import xc
-import config
+from . import unitconv
+from . import xc
+from . import config
 
 
 # define some custom types

--- a/atoMEC/convergence.py
+++ b/atoMEC/convergence.py
@@ -8,8 +8,8 @@ Module which handles convergence routines
 import numpy as np
 
 # internal modules
-import mathtools
-import config
+from . import mathtools
+from . import config
 
 
 class SCF:

--- a/atoMEC/mathtools.py
+++ b/atoMEC/mathtools.py
@@ -11,7 +11,7 @@ import numpy as np
 from scipy import optimize, integrate
 
 # internal libraries
-import config
+from . import config
 
 
 def normalize_orbs(eigfuncs_x, xgrid):

--- a/atoMEC/models.py
+++ b/atoMEC/models.py
@@ -6,12 +6,12 @@ from mendeleev import element
 from math import pi, log
 
 # import internal packages
-import check_inputs
-import config
-import staticKS
-import convergence
-import writeoutput
-import xc
+from . import check_inputs
+from . import config
+from . import staticKS
+from . import convergence
+from . import writeoutput
+from . import xc
 
 
 class ISModel:

--- a/atoMEC/numerov.py
+++ b/atoMEC/numerov.py
@@ -15,9 +15,9 @@ from joblib import Parallel, delayed, dump, load
 # from staticKS import Orbitals
 
 # internal libs
-import config
-import mathtools
-import writeoutput
+from . import config
+from . import mathtools
+from . import writeoutput
 
 
 # @writeoutput.timing

--- a/atoMEC/staticKS.py
+++ b/atoMEC/staticKS.py
@@ -9,10 +9,10 @@ import numpy as np
 from math import sqrt, pi, exp
 
 # internal modules
-import config
-import numerov
-import mathtools
-import xc
+from . import config
+from . import numerov
+from . import mathtools
+from . import xc
 
 # the logarithmic grid
 def log_grid(x_r):

--- a/atoMEC/unitconv.py
+++ b/atoMEC/unitconv.py
@@ -2,9 +2,6 @@
 Contains unit conversions
 """
 
-import config
-
-
 cm_to_bohr = 1.889716165e8
 ev_to_ha = 3.6749308136649e-2
 K_to_ha = 3.166808534191e-6

--- a/atoMEC/writeoutput.py
+++ b/atoMEC/writeoutput.py
@@ -11,8 +11,8 @@ import numpy as np
 import tabulate
 
 # internal libs
-import unitconv
-import config
+from . import unitconv
+from . import config
 
 # define some line spacings
 spc = "\n"

--- a/atoMEC/xc.py
+++ b/atoMEC/xc.py
@@ -9,8 +9,8 @@ import pylibxc
 import numpy as np
 
 # internal libs
-import config
-import mathtools
+from . import config
+from . import mathtools
 
 # list of special codes for functionals not defined by libxc
 xc_special_codes = ["hartree", "None"]

--- a/atoMEC/xc.py
+++ b/atoMEC/xc.py
@@ -217,7 +217,7 @@ def calc_xc(density, xgrid, xcfunc, xctype):
     elif xcfunc._number == -1:
 
         # import the staticKS module
-        import staticKS
+        from . import staticKS
 
         if xctype == "v_xc":
             xc_arr[:] = -staticKS.Potential.calc_v_ha(density, xgrid)


### PR DESCRIPTION
Fixes import problems:

```sh
❯ python
Python 3.9.5 (default, May 14 2021, 00:00:00)
[GCC 11.1.1 20210428 (Red Hat 11.1.1-1)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import atoMEC
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "...../atoMEC/__init__.py", line 8, in <module>
    import config
ModuleNotFoundError: No module named 'config'
>>>
```