### PR TITLE
Relax Python version restriction to be any version of Python 3:

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -12,4 +12,4 @@ pylibxc2 = ">=6.0.0"
 joblib = ">=1.0.1"
 
 [requires]
-python_version = "3.8"
+python_version = "3"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "26982e0e7ca53283c0d3f7e4588e393763aa38c706c9fa4431f01c9e678cdc2a"
+            "sha256": "8ce22a098c60580e4edbe43738d596eac8c3f624337c9138143fd2f7641ee526"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.8"
+            "python_version": "3"
         },
         "sources": [
             {


### PR DESCRIPTION
Pipenv supports only hard Python version specification, no minimum
version. In order to avoid warnings from pipenv when using a newer
version of Python than 3.8, we lift this resrticion here to be of
version of any 3.x.x.