### PR TITLE
Fix issue when there are no bound levels

### DIFF
--- a/atoMEC/staticKS.py
+++ b/atoMEC/staticKS.py
@@ -75,13 +75,15 @@ class Orbitals:
     @property
     def occnums(self):
         if np.all(self._occnums == 0.0):
-            raise Exception("Occnums have not been initialized")
+            # raise Exception("Occnums have not been initialized")
+            self._occnums = self.calc_occnums(self.eigvals, self.lbound, config.mu)
         return self._occnums
 
     @property
     def lbound(self):
         if np.all(self._lbound == 0.0):
-            raise Exception("lbound has not been initialized")
+            # raise Exception("lbound has not been initialized")
+            self._lbound = self.make_lbound(self.eigvals)
         return self._lbound
 
     def compute(self, potential, init=False):

--- a/atoMEC/writeoutput.py
+++ b/atoMEC/writeoutput.py
@@ -391,12 +391,16 @@ class SCF:
         for i in range(config.spindims):
 
             # truncate the table to include only one unbound state in each direction
-            lmax_new = min(
-                np.amax(np.where(orbitals.eigvals[i] < 0)[0]) + 2, config.lmax
-            )
-            nmax_new = min(
-                np.amax(np.where(orbitals.eigvals[i] < 0)[1]) + 2, config.nmax
-            )
+            try:
+                lmax_new = min(
+                    np.amax(np.where(orbitals.eigvals[i] < 0)[0]) + 2, config.lmax
+                )
+                nmax_new = min(
+                    np.amax(np.where(orbitals.eigvals[i] < 0)[1]) + 2, config.nmax
+                )
+            except ValueError:
+                lmax_new = 2
+                nmax_new = 2
 
             # define row and column headers
             headers = [n + 1 for n in range(nmax_new)]


### PR DESCRIPTION
Fixes problems in `staticKS.py` and `writeoutput.py` which occur when there are no bound levels.

The solution is to re-compute `staticKS.Orbitals.lbound` and `staticKS.Orbitals.occnums` whenever they are identically zero, and add an error exception in `write_orb_info` when there are no bound levels
