### PR TITLE
Fix docs in `staticKS.py`

### DIFF
--- a/atoMEC/staticKS.py
+++ b/atoMEC/staticKS.py
@@ -442,31 +442,6 @@ class Potential:
 class Energy:
     r"""
     Holds information about the KS total energy and relevant routines
-
-    Attributes
-    ----------
-    F_tot : dict of floats
-        contains the keys "F", "E" and "S" for free energy, internal energy and
-        total entropy. See notes for definitions of F and E.
-
-
-    E_kin : dict of floats
-        the kinetic energy, split into "bound" and "unbound" terms
-    E_en : float
-        the electron-nuclear energy
-    E_ha : float
-        the Hartree energy
-    E_xc : dict of floats
-        the exchange correlation energy containing the keys
-        "x", "c" and "xc" for exchange, correlation, and exchange + correlation
-
-    Notes
-    -----
-    The free energy :math:`F` and internal energy :math:`E` are defined as
-
-    .. math::
-        F &= E - TS \\
-        E &= T_\mathrm{s} + E_\mathrm{en} + E_\mathrm{ha} + F_\mathrm{xc}
     """
 
     def __init__(self, orbs, dens):
@@ -487,42 +462,51 @@ class Energy:
 
     @property
     def F_tot(self):
+        r"""dict of floats: contains the keys "F", "E" and "S" for free energy, internal energy and
+        total entropy. :math:`F = E - TS`"""
         if self._F_tot == 0.0:
             self._F_tot = self.E_tot - config.temp * self.entropy["tot"]
         return self._F_tot
 
     @property
     def E_tot(self):
+        r"""float: the total KS internal energy :math:`E=T_\mathrm{s}+E_\mathrm{en}+E_\mathrm{ha}+F_\mathrm{xc}`"""
         if self._E_tot == 0.0:
             self._E_tot = self.E_kin["tot"] + self.E_en + self.E_ha + self.E_xc["xc"]
         return self._E_tot
 
     @property
     def entropy(self):
+        """dict of floats: total entropy containing "bound" and "unbound" keys"""
         if self._entropy["tot"] == 0.0:
             self._entropy = self.calc_entropy(self._orbs)
         return self._entropy
 
     @property
     def E_kin(self):
+        """dict of floats: KS kinetic energy containing "bound" and "unbound" keys"""
         if self._E_kin["tot"] == 0.0:
             self._E_kin = self.calc_E_kin(self._orbs, self._xgrid)
         return self._E_kin
 
     @property
     def E_en(self):
+        """float: the electron-nuclear energy"""
         if self._E_en == 0.0:
             self._E_en = self.calc_E_en(self._dens, self._xgrid)
         return self._E_en
 
     @property
     def E_ha(self):
+        """float: the Hartree energy"""
         if self._E_ha == 0.0:
             self._E_ha = self.calc_E_ha(self._dens, self._xgrid)
         return self._E_ha
 
     @property
     def E_xc(self):
+        """dict of floats: the xc energy, containing keys "x", "c" and "xc"
+        for exchange, correlation and exchange + correlation respectively"""
         if self._E_xc["xc"] == 0.0:
             self._E_xc = xc.E_xc(self._dens, self._xgrid, config.xfunc, config.cfunc)
         return self._E_xc

--- a/atoMEC/staticKS.py
+++ b/atoMEC/staticKS.py
@@ -233,7 +233,7 @@ class Density:
 
     @property
     def bound(self):
-        """dict of ndarrays: Contains the keys "rho" and "N" denoting the bound
+        """dict of ndarrays: Contains the keys `rho` and `N` denoting the bound
         density and number of bound electrons respectively
         """
         if np.all(self._bound["rho"] == 0.0):
@@ -242,7 +242,7 @@ class Density:
 
     @property
     def unbound(self):
-        """dict of ndarrays: contains the keys "rho" and "N" denoting the
+        """dict of ndarrays: contains the keys `rho` and `N` denoting the
         unbound density and number of unbound electrons respectively
         """
         if np.all(self._unbound["rho"]) == 0.0:
@@ -264,7 +264,7 @@ class Density:
         Returns
         -------
         rho_bound : dict of ndarrays
-            contains the keys "rho" and "N" denoting the bound density
+            contains the keys `rho` and `N` denoting the bound density
             and number of bound electrons respectively
         """
 
@@ -301,7 +301,7 @@ class Density:
         Returns
         -------
         rho_unbound : dict of ndarrays
-            contains the keys "rho" and "N" denoting the unbound density
+            contains the keys `rho` and `N` denoting the unbound density
             and number of unbound electrons respectively
         """
 
@@ -368,7 +368,7 @@ class Potential:
 
     @property
     def v_xc(self):
-        r"""dict of ndarrays: the xc-potential, contains the keys "x", "c" and "xc"
+        r"""dict of ndarrays: the xc-potential, contains the keys `x`, `c` and `xc`
         denoting exchange, correlation, and exchange + correlation respectively"""
         if np.all(self._v_xc["xc"] == 0.0):
             self._v_xc = xc.v_xc(self._density, self._xgrid, config.xfunc, config.cfunc)
@@ -462,7 +462,7 @@ class Energy:
 
     @property
     def F_tot(self):
-        r"""dict of floats: contains the keys "F", "E" and "S" for free energy, internal energy and
+        r"""dict of floats: contains the keys `F`, `E` and `S` for free energy, internal energy and
         total entropy. :math:`F = E - TS`"""
         if self._F_tot == 0.0:
             self._F_tot = self.E_tot - config.temp * self.entropy["tot"]
@@ -477,14 +477,14 @@ class Energy:
 
     @property
     def entropy(self):
-        """dict of floats: total entropy containing "bound" and "unbound" keys"""
+        """dict of floats: total entropy containing `bound` and `unbound` keys"""
         if self._entropy["tot"] == 0.0:
             self._entropy = self.calc_entropy(self._orbs)
         return self._entropy
 
     @property
     def E_kin(self):
-        """dict of floats: KS kinetic energy containing "bound" and "unbound" keys"""
+        """dict of floats: KS kinetic energy containing `bound` and `unbound` keys"""
         if self._E_kin["tot"] == 0.0:
             self._E_kin = self.calc_E_kin(self._orbs, self._xgrid)
         return self._E_kin
@@ -505,7 +505,7 @@ class Energy:
 
     @property
     def E_xc(self):
-        """dict of floats: the xc energy, containing keys "x", "c" and "xc"
+        """dict of floats: the xc energy, containing keys `x`, `c` and `xc`
         for exchange, correlation and exchange + correlation respectively"""
         if self._E_xc["xc"] == 0.0:
             self._E_xc = xc.E_xc(self._dens, self._xgrid, config.xfunc, config.cfunc)
@@ -528,7 +528,7 @@ class Energy:
         Returns
         -------
         E_kin : dict of ndarrays
-            Contains "total", "bound" and "unbound" keys
+            Contains `tot`, `bound` and `unbound` keys
         """
 
         E_kin = {}
@@ -634,7 +634,7 @@ class Energy:
         Returns
         -------
         S : dict of floats
-           contains "total", "bound" and "unbound" keys
+           contains `tot`, `bound` and `unbound` keys
         """
 
         S = {}

--- a/atoMEC/staticKS.py
+++ b/atoMEC/staticKS.py
@@ -215,20 +215,10 @@ class Density:
     """
     Holds the static KS density and routines required to compute its components
 
-    Attributes
     ----------
-    total : ndarray
-        the total KS density n(r) or n(x)
-    bound : dict of ndarrays
-        contains the keys "rho" and "N" denoting the bound density
-        and number of bound electrons respectively
-    unbound : dict of ndarrays
-        contains the keys "rho" and "N" denoting the unbound density
-        and number of unbound electrons respectively
     """
 
     def __init__(self, orbs):
-
         self._xgrid = orbs._xgrid
         self._total = np.zeros((config.spindims, config.grid_params["ngrid"]))
         self._bound = {
@@ -244,18 +234,25 @@ class Density:
 
     @property
     def total(self):
+        """ndarray: Total KS density :math:`n(r)` or :math:`n(x)`"""
         if np.all(self._total == 0.0):
             self._total = self.bound["rho"] + self.unbound["rho"]
         return self._total
 
     @property
     def bound(self):
+        """dict of ndarrays: Contains the keys "rho" and "N" denoting the bound
+        density and number of bound electrons respectively
+        """
         if np.all(self._bound["rho"] == 0.0):
             self._bound = self.construct_rho_bound(self._orbs, self._xgrid)
         return self._bound
 
     @property
     def unbound(self):
+        """dict of ndarrays: contains the keys "rho" and "N" denoting the
+        unbound density and number of unbound electrons respectively
+        """
         if np.all(self._unbound["rho"]) == 0.0:
             self._unbound = self.construct_rho_unbound(self._orbs)
         return self._unbound

--- a/atoMEC/staticKS.py
+++ b/atoMEC/staticKS.py
@@ -217,8 +217,8 @@ class Density:
 
     Parameters
     ----------
-    orbs : type
-        Description of `orbs`.
+    orbs : :obj:`staticKS.Orbitals`
+        The KS orbitals object
     """
 
     def __init__(self, orbs):

--- a/atoMEC/staticKS.py
+++ b/atoMEC/staticKS.py
@@ -330,21 +330,7 @@ class Density:
 
 
 class Potential:
-    """
-    Holds the KS potential and the routines required to compute it
-
-    Attributes
-    ----------
-    v_s : ndarray
-        the full KS potential :math:`v_\mathrm{s} = v_\mathrm{en} + v_\mathrm{ha} + v_\mathrm{xc}`
-    v_en : ndarray
-        the electron-nuclear potential
-    v_ha : ndarray
-        the hartree potential
-    v_xc : dict of ndarrays
-        the xc-potential, contains the keys "x", "c" and "xc"
-        denoting exchange, correlation, and exchange + correlation respectively
-    """
+    """Holds the KS potential and the routines required to compute it"""
 
     def __init__(self, density):
 
@@ -361,24 +347,29 @@ class Potential:
 
     @property
     def v_s(self):
+        r"""ndarray: the full KS potential :math:`v_\mathrm{s} = v_\mathrm{en} + v_\mathrm{ha} + v_\mathrm{xc}`"""
         if np.all(self._v_s == 0.0):
             self._v_s = self.v_en + self.v_ha + self.v_xc["xc"]
         return self._v_s
 
     @property
     def v_en(self):
+        r"""ndarray: the electron-nuclear potential"""
         if np.all(self._v_en == 0.0):
             self._v_en = self.calc_v_en(self._xgrid)
         return self._v_en
 
     @property
     def v_ha(self):
+        r"""ndarray: the Hartree potential"""
         if np.all(self._v_ha == 0.0):
             self._v_ha = self.calc_v_ha(self._density, self._xgrid)
         return self._v_ha
 
     @property
     def v_xc(self):
+        r"""dict of ndarrays: the xc-potential, contains the keys "x", "c" and "xc"
+        denoting exchange, correlation, and exchange + correlation respectively"""
         if np.all(self._v_xc["xc"] == 0.0):
             self._v_xc = xc.v_xc(self._density, self._xgrid, config.xfunc, config.cfunc)
         return self._v_xc
@@ -412,11 +403,12 @@ class Potential:
 
         .. math::
             v_\mathrm{ha}(r) = 4\pi\int_0^r \mathrm{d}r' r'^2 \frac{n(r')}{\max(r,r')}
+
         On the x-grid:
 
         .. math::
             v_\mathrm{ha}(x) = 4\pi\Big\{\exp(-x)\int_{x0}^x \mathrm{d}x' n(x') \exp(3x') \\
-                               -\int_x^{\log(r_s)} \mathrm{d}x' n(x') \exp(2x') \Big\}
+            -\int_x^{\log(r_s)} \mathrm{d}x' n(x') \exp(2x') \Big\}
         """
 
         # initialize v_ha

--- a/atoMEC/staticKS.py
+++ b/atoMEC/staticKS.py
@@ -584,7 +584,7 @@ class Energy:
     @staticmethod
     def calc_E_kin_unbound(orbs, xgrid):
         r"""
-
+        Compute the contribution from unbound (continuum) electrons to kinetic energy.
 
         Parameters
         ----------

--- a/atoMEC/staticKS.py
+++ b/atoMEC/staticKS.py
@@ -42,20 +42,7 @@ def log_grid(x_r):
 
 
 class Orbitals:
-    r"""
-    Class holding the KS orbitals, associated quantities and relevant routines
-
-    Attributes
-    ----------
-    eigfuncs : ndarray
-        the KS radial eigenfunctions on the logarithmic grid
-    eigvals : ndarray
-        the KS eigenvalues
-    occnums : ndarray
-        the KS orbital occupation numbers including degeneracy (see notes)
-    lbound : ndarray
-        matrix :math:`L^\mathrm{B}_{ln}=(2l+1)\times\Theta(\epsilon_{nl})`
-    """
+    """Class holding the KS orbitals, associated quantities and relevant routines"""
 
     def __init__(self, xgrid):
 
@@ -69,21 +56,22 @@ class Orbitals:
 
     @property
     def eigvals(self):
-        """KS eigenvalues"""
+        r"""ndarray: the KS eigenvalues :math:`\epsilon_{nl}^\sigma`"""
         if np.all(self._eigvals == 0.0):
             raise Exception("Eigenvalues have not been initialized")
         return self._eigvals
 
     @property
     def eigfuncs(self):
-        """KS eigenfunctions"""
+        r"""ndarray: the radial KS eigenfunctions on the logarithmic grid
+        :math:`X_{nl}^{\sigma}(r)`"""
         if np.all(self._eigfuncs == 0.0):
             raise Exception("Eigenfunctions have not been initialized")
         return self._eigfuncs
 
     @property
     def occnums(self):
-        """KS occupation numbers"""
+        r"""ndarray: the KS occupation numbers multiplied by the :obj:`lbound` matrix"""
         if np.all(self._occnums == 0.0):
             # raise Exception("Occnums have not been initialized")
             self._occnums = self.calc_occnums(self.eigvals, self.lbound, config.mu)
@@ -91,7 +79,8 @@ class Orbitals:
 
     @property
     def lbound(self):
-        """Matrix denoting bound eigenvalues and their degeneracies"""
+        r"""ndarray: matrix denoting bound eigenvalues and their degeneracies (DOS).
+        The matrix takes the form :math:`L^\mathrm{B}_{ln}=(2l+1)\times\Theta(\epsilon_{nl})`"""
         if np.all(self._lbound == 0.0):
             # raise Exception("lbound has not been initialized")
             self._lbound = self.make_lbound(self.eigvals)

--- a/atoMEC/staticKS.py
+++ b/atoMEC/staticKS.py
@@ -206,7 +206,7 @@ class Density:
 
     Parameters
     ----------
-    orbs : :obj:`staticKS.Orbitals`
+    orbs : :obj:`Orbitals`
         The KS orbitals object
     """
 
@@ -520,7 +520,7 @@ class Energy:
 
         Parameters
         ----------
-        orbs : object
+        orbs : :obj:`Orbitals`
             the KS orbitals object
         xgrid : ndarray
             the logarithmic grid
@@ -551,7 +551,7 @@ class Energy:
 
         Parameters
         ----------
-        orbs : object
+        orbs : :obj:`Orbitals`
             the KS orbitals object
         xgrid : ndarray
             the logarithmic grid
@@ -588,7 +588,7 @@ class Energy:
 
         Parameters
         ----------
-        orbs : object
+        orbs : :obj:`Orbitals`
             the KS orbitals object
         xgrid : ndarray
             the logarithmic grid
@@ -628,7 +628,7 @@ class Energy:
 
         Parameters
         ----------
-        orbs : object
+        orbs : :obj:`Orbitals`
             the KS orbitals object
 
         Returns
@@ -657,7 +657,7 @@ class Energy:
 
         Parameters
         ----------
-        orbs : object
+        orbs : :obj:`Orbitals`
             the KS orbitals object
 
         Returns
@@ -705,7 +705,7 @@ class Energy:
 
         Parameters
         ----------
-        orbs : object
+        orbs : :obj:`Orbitals`
             the KS orbitals object
 
         Returns

--- a/atoMEC/staticKS.py
+++ b/atoMEC/staticKS.py
@@ -215,7 +215,10 @@ class Density:
     """
     Holds the static KS density and routines required to compute its components
 
+    Parameters
     ----------
+    orbs : type
+        Description of `orbs`.
     """
 
     def __init__(self, orbs):


### PR DESCRIPTION
@timcallow : Please fix the following issues:

- [x]  add a description for parameter `orbs` in class `Density` and change `type` to the correct one
- [x]  fix the documentation of properties for classes `Orbitals`, `Potential` and `Energy` in a similar way as I have done it for `Density`

Please refer to the following documents:

- https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html
- https://mkapi.daizutabi.net/examples/numpy_style/

The provided commits fix warnings a la:
```
.../atoMEC_import/atoMEC/staticKS.py:docstring of atoMEC.staticKS.Density.bound:1:duplicate
object description of atoMEC.staticKS.Density.bound, other instance in api/atoMEC, use :noindex: for one of them
```

Always check locally with `make clean` and `make html` (or `make SPHINXOPTS="-W" html`).

Once this PR is ready for review, let me know;)