### PR TITLE
Fix docstring errors in `__init__.py`

### DIFF
--- a/atoMEC/__init__.py
+++ b/atoMEC/__init__.py
@@ -12,7 +12,7 @@ from . import writeoutput
 
 
 class Atom:
-    """
+    r"""
     The Atom class defines the main atom object containing the key information about the
     atomic species, temperature, density etc
 
@@ -26,7 +26,7 @@ class Atom:
         The radius of the Wigner-Seitz sphere, defined as 0.5*a_i,
         where a_i is the average inter-atomic distance
     density : float, optional
-        The mass density of the material in g cm^-3
+        The mass density of the material in :math:`\mathrm{g\ cm}^{-3}`
     charge : int, optional
         The overall net charge
     units_temp : str, optional
@@ -37,28 +37,6 @@ class Atom:
         The units of density, currently only "g/cm3" is supported
     write_output : bool, optional
         Whether to print atomic information, defaults True
-
-    Attributes
-    ----------
-    species : str
-        The chemical symbol for the atomic species
-    temp : float
-        The electronic temperature in hartree
-    radius : float
-        The radius of the Wigner-Seitz sphere, defined as 0.5*a_i,
-        where a_i is the average inter-atomic distance
-    density : float
-        The mass density of the material in g cm^-3
-    charge : int, optional
-        The overall net charge
-    at_chrg : int
-        The atomic number Z
-    at_mass : float
-        The atomic mass
-    nele : int
-        The total electron number
-    info : str
-        Information about the atom
     """
 
     def __init__(
@@ -104,6 +82,7 @@ class Atom:
 
     @property
     def species(self):
+        """str: the chemical symbol for the atomic species"""
         return self._species
 
     @species.setter
@@ -112,16 +91,19 @@ class Atom:
 
     @property
     def at_chrg(self):
+        """int: the atomic charge Z"""
         chrg = self.species.atomic_number
         config.Z = chrg
         return chrg
 
     @property
     def at_mass(self):
+        """float: the atomic mass (in a.u.)"""
         return self.species.atomic_weight
 
     @property
     def units_temp(self):
+        """str: the units of temperature"""
         return self._units_temp
 
     @units_temp.setter
@@ -130,6 +112,7 @@ class Atom:
 
     @property
     def temp(self):
+        """float: the electronic temperature in Hartree"""
         return self._temp
 
     @temp.setter
@@ -140,6 +123,7 @@ class Atom:
 
     @property
     def charge(self):
+        """int: the net charge of the atom"""
         return self._charge
 
     @charge.setter
@@ -148,10 +132,13 @@ class Atom:
 
     @property
     def nele(self):
+        """int: the number of electrons in the atom, given by the
+        sum of :obj:`at_chrg` and :obj:`charge`"""
         return self.at_chrg + self._charge
 
     @property
     def units_radius(self):
+        """str: the units of the atomic radius"""
         return self._units_radius
 
     @units_radius.setter
@@ -160,6 +147,7 @@ class Atom:
 
     @property
     def units_density(self):
+        """str: the units of the atomic density"""
         return self._units_density
 
     @units_density.setter
@@ -168,6 +156,8 @@ class Atom:
 
     @property
     def radius(self):
+        r"""float: radius of the Wigner-Seitz sphere, defined as :math:`0.5*a_i`,
+        where :math:`a_i` is the average inter-atomic distance"""
         return self._radius
 
     @radius.setter
@@ -179,6 +169,7 @@ class Atom:
 
     @property
     def density(self):
+        """float: the mass density of the material in units :math:`\mathrm{g\ cm}^{-3}`"""
         return self._density
 
     @density.setter
@@ -190,5 +181,6 @@ class Atom:
 
     @property
     def info(self):
+        """str: formatted information about the :obj:`Atom`'s attributes"""
         # write output info
         return writeoutput.write_atomic_data(self)

--- a/atoMEC/__init__.py
+++ b/atoMEC/__init__.py
@@ -156,7 +156,7 @@ class Atom:
 
     @property
     def radius(self):
-        r"""float: radius of the Wigner-Seitz sphere, defined as :math:`0.5*a_i`,
+        r"""float: radius of the Wigner-Seitz sphere, defined as :math:`a_i /2`,
         where :math:`a_i` is the average inter-atomic distance"""
         return self._radius
 
@@ -169,7 +169,7 @@ class Atom:
 
     @property
     def density(self):
-        """float: the mass density of the material in units :math:`\mathrm{g\ cm}^{-3}`"""
+        r"""float: the mass density of the material in units :math:`\mathrm{g\ cm}^{-3}`"""
         return self._density
 
     @density.setter


### PR DESCRIPTION
Fixes the warnings:

![docerrors_screenshot](https://user-images.githubusercontent.com/18050753/123557471-3ab37000-d791-11eb-935f-3db31c71e804.png)
