### PR TITLE
Fix `pydocstyle` errors in `__init__.py`

### DIFF
--- a/atoMEC/__init__.py
+++ b/atoMEC/__init__.py
@@ -1,3 +1,17 @@
+"""
+atoMEC: Average-atom code for matter under extreme conditions.
+
+Copyright (c) 2021 (in alphabetical order), Tim Callow, Attila Cangi, Eli Kraisler
+All rights reserved.
+
+atoMEC is a python-based average-atom code for simulations of high energy density phenomena such as in warm dense matter.
+Please see the README or the project wiki (https://atomec-project.github.io/atoMEC/) for more information.
+
+Classes
+-------
+Atom : the main object for atoMEC calculations, containing information about physical material properties
+"""
+
 # standard libraries
 from math import pi
 
@@ -13,8 +27,10 @@ from . import writeoutput
 
 class Atom:
     r"""
-    The Atom class defines the main atom object containing the key information about the
-    atomic species, temperature, density etc
+    The principal object in atoMEC calculations which defines the physical material properties.
+
+    The `Atom` contains key information about the physical properties of the material
+    such as temperature, density, and charge. It does not contain any information about approximations or choices of model.
 
     Parameters
     ----------
@@ -82,7 +98,7 @@ class Atom:
 
     @property
     def species(self):
-        """str: the chemical symbol for the atomic species"""
+        """str: the chemical symbol for the atomic species."""
         return self._species
 
     @species.setter
@@ -91,19 +107,19 @@ class Atom:
 
     @property
     def at_chrg(self):
-        """int: the atomic charge Z"""
+        """int: the atomic charge Z."""
         chrg = self.species.atomic_number
         config.Z = chrg
         return chrg
 
     @property
     def at_mass(self):
-        """float: the atomic mass (in a.u.)"""
+        """float: the atomic mass (in a.u.)."""
         return self.species.atomic_weight
 
     @property
     def units_temp(self):
-        """str: the units of temperature"""
+        """str: the units of temperature."""
         return self._units_temp
 
     @units_temp.setter
@@ -112,7 +128,7 @@ class Atom:
 
     @property
     def temp(self):
-        """float: the electronic temperature in Hartree"""
+        """float: the electronic temperature in Hartree."""
         return self._temp
 
     @temp.setter
@@ -123,7 +139,7 @@ class Atom:
 
     @property
     def charge(self):
-        """int: the net charge of the atom"""
+        """int: the net charge of the atom."""
         return self._charge
 
     @charge.setter
@@ -132,13 +148,15 @@ class Atom:
 
     @property
     def nele(self):
-        """int: the number of electrons in the atom, given by the
-        sum of :obj:`at_chrg` and :obj:`charge`"""
+        """int: the number of electrons in the atom.
+
+        The total electron number is given by the sum of :obj:`at_chrg` and :obj:`charge`.
+        """
         return self.at_chrg + self._charge
 
     @property
     def units_radius(self):
-        """str: the units of the atomic radius"""
+        """str: the units of the atomic radius."""
         return self._units_radius
 
     @units_radius.setter
@@ -147,7 +165,7 @@ class Atom:
 
     @property
     def units_density(self):
-        """str: the units of the atomic density"""
+        """str: the units of the atomic density."""
         return self._units_density
 
     @units_density.setter
@@ -156,8 +174,11 @@ class Atom:
 
     @property
     def radius(self):
-        r"""float: radius of the Wigner-Seitz sphere, defined as :math:`a_i /2`,
-        where :math:`a_i` is the average inter-atomic distance"""
+        r"""float: radius of the Wigner-Seitz sphere.
+
+        The radius is defined as :math:`a_i /2`,
+        where :math:`a_i` is the average inter-atomic distance.
+        """
         return self._radius
 
     @radius.setter
@@ -169,7 +190,7 @@ class Atom:
 
     @property
     def density(self):
-        r"""float: the mass density of the material in units :math:`\mathrm{g\ cm}^{-3}`"""
+        r"""float: the mass density of the material in units :math:`\mathrm{g\ cm}^{-3}`."""
         return self._density
 
     @density.setter
@@ -181,6 +202,6 @@ class Atom:
 
     @property
     def info(self):
-        """str: formatted information about the :obj:`Atom`'s attributes"""
+        """str: formatted information about the :obj:`Atom`'s attributes."""
         # write output info
         return writeoutput.write_atomic_data(self)


### PR DESCRIPTION
Fixes `pydocstyle` errors in `__init__.py` and also adds short description of package / module contents.