### PR TITLE
Fix convergence issues

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 88
+extend-ignore = E203,D107

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -5,12 +5,14 @@ on:
     branches:
       - master
       - develop
+      - documenation
   push:
     branches:
+      - documentation
       - develop
 
 jobs:
-  test-docstrings:
+  python-style-checks:
     runs-on: ubuntu-18.04
     steps:
       - name: Check out repository
@@ -25,13 +27,16 @@ jobs:
         run: python3 -m pip install --upgrade pip
 
       - name: Install dependencies
-        run: pip install -qU pydocstyle
+        run: pip install -qU pydocstyle flake8
 
       - name: Check docstrings
         run: pydocstyle --convention=numpy atoMEC
 
+      - name: Lint with flake8
+        run: flake8 atoMEC --count --show-source --statistics
+
   build-and-deploy-pages:
-    needs: test-docstrings
+    needs: python-style-checks
     runs-on: ubuntu-18.04
     steps:
       - name: Check out repository

--- a/atoMEC/convergence.py
+++ b/atoMEC/convergence.py
@@ -1,5 +1,11 @@
 """
-Module which handles convergence routines
+Contains classes and functions used to compute and store aspects related to convergence.
+
+So far, the only procedure requring convergence is the static SCF cycle. More will be added in future.
+
+Classes
+-------
+SCF : holds the SCF convergence attributes and calculates them for the given cycle
 """
 
 # standard libraries
@@ -14,7 +20,7 @@ from . import config
 
 class SCF:
     """
-    Convergence attributes and functions related to SCF energy procedures
+    Convergence attributes and functions related to SCF energy procedures.
 
     Notes
     -----
@@ -31,8 +37,10 @@ class SCF:
 
     def check_conv(self, E_free, pot, dens, iscf):
         """
-        Computes the changes in energy, integrated density and integrated potential
-        and checks if they satisfy the proscribed convergence parameters
+        Compute and check the changes in energy, integrated density and integrated potential.
+
+        If the convergence tolerances are all simultaneously satisfied, the `complete` variable
+        returns `True` as the SCF cycle is complete.
 
         Parameters
         ----------
@@ -53,9 +61,7 @@ class SCF:
             `conv_energy` : ``float``,   `conv_rho` : ``ndarray``,
             `conv_pot`    : ``ndarray``, `complete` : ``bool``
             }
-
         """
-
         conv_vals = {}
 
         # first update the energy, potential and density attributes

--- a/atoMEC/mathtools.py
+++ b/atoMEC/mathtools.py
@@ -1,9 +1,25 @@
-"""
-Low-level module containing various mathematical functions
+r"""
+Low-level module containing miscalleneous mathematical functions.
+
+Functions
+---------
+normalize_orbs: normalize KS orbitals within defined sphere
+
+int_sphere: integral :math:`4\pi \int \mathrm{d}r r^2 f(r)`
+
+lapalce: compute the second-order derivative :math:`d^2 y(x) / dx^2`
+
+fermi_dirac: compute the Fermi-Dirac occupation function (for given order n)
+
+fd_int_complete: compute the complete Fermi-Dirac integral (for given order n)
+
+chem_pot: compute the chemical potential by enforcing charge neutrality
+
+f_root_id: make root input function for chem_pot with ideal approx for free electrons
 """
 
 # standard libraries
-from math import sqrt, pi, exp
+from math import sqrt, pi
 import warnings
 
 # external libraries

--- a/atoMEC/mathtools.py
+++ b/atoMEC/mathtools.py
@@ -32,7 +32,7 @@ from . import config
 
 def normalize_orbs(eigfuncs_x, xgrid):
     r"""
-    Normalizes the KS orbitals within the chosen sphere
+    Normalize the KS orbitals within the chosen sphere.
 
     Parameters
     ----------
@@ -46,7 +46,6 @@ def normalize_orbs(eigfuncs_x, xgrid):
     eigfuncs_x_norm : ndarray
         The radial KS eigenfunctions normalized over the chosen sphere
     """
-
     # initialize the normalized eigenfunctions
     eigfuncs_x_norm = eigfuncs_x
 
@@ -65,8 +64,9 @@ def normalize_orbs(eigfuncs_x, xgrid):
 
 def int_sphere(fx, xgrid):
     r"""
-    Computes integrals over the sphere defined by the logarithmic
-    grid provided as input
+    Compute integral over sphere defined by input grid.
+
+    The integral is performed on the logarithmic grid (see notes).
 
     Parameters
     ----------
@@ -86,7 +86,6 @@ def int_sphere(fx, xgrid):
 
     .. math:: I = 4 \pi \int \mathrm{d}x\ e^{3x} f(x)
     """
-
     func_int = 4.0 * pi * np.exp(3.0 * xgrid) * fx
     I_sph = np.trapz(func_int, xgrid)
 
@@ -95,8 +94,9 @@ def int_sphere(fx, xgrid):
 
 def laplace(y, x, axis=-1):
     r"""
-    Computes the second-order derivative :math:`d^2 y(x) / dx^2`
-    over the chosen axis of the input array
+    Compute the second-order derivative :math:`d^2 y(x) / dx^2`.
+
+    Derivative can be computed over any given axis.
 
     Parameters
     ----------
@@ -113,7 +113,6 @@ def laplace(y, x, axis=-1):
     grad2_y : ndarray
         the laplacian of y
     """
-
     # first compute the first-order gradient
     grad1_y = np.gradient(y, x, edge_order=2, axis=axis)
 
@@ -125,7 +124,7 @@ def laplace(y, x, axis=-1):
 
 def fermi_dirac(eps, mu, beta, n=0):
     r"""
-    Computes the Fermi-Dirac function, see notes
+    Compute the Fermi-Dirac function, see notes for functional form.
 
     Parameters
     ----------
@@ -147,9 +146,9 @@ def fermi_dirac(eps, mu, beta, n=0):
     -----
     The FD function is defined as:
 
-    .. math:: f^{(n)}_{fd}(\epsilon, \mu, \beta) = \frac{\epsilon^{n/2}}{1+\exp(1+\beta(\epsilon - \mu))}
+    .. math:: f^{(n)}_{fd}(\epsilon, \mu, \beta) = \frac{\epsilon^{n/2}}{1+\exp(1+
+        \beta(\epsilon - \mu))}
     """
-
     # dfn the exponential function
     # ignore warnings here
     with np.errstate(over="ignore"):
@@ -163,7 +162,7 @@ def fermi_dirac(eps, mu, beta, n=0):
 
 def fd_int_complete(mu, beta, n):
     r"""
-    Computes complete Fermi-Dirac integrals (see notes)
+    Compute complete Fermi-Dirac integral for given order (see notes for function form).
 
     Parameters
     ----------
@@ -185,11 +184,11 @@ def fd_int_complete(mu, beta, n):
 
     .. math::
 
-        I_{n}(\mu,\beta)=\int_0^\infty\mathrm{d}\epsilon\ \epsilon^{n/2}f_{fd}(\mu,\epsilon,\beta)
+        I_{n}(\mu,\beta)=\int_0^\infty\mathrm{d}\epsilon\ \epsilon^{n/2}f_{fd}
+        (\mu,\epsilon,\beta)
 
     where n is the order of the integral
     """
-
     # use scipy quad integration routine
     limup = np.inf
 
@@ -203,12 +202,13 @@ def fd_int_complete(mu, beta, n):
 
 def chem_pot(orbs):
     r"""
-    Determines the chemical potential by enforcing charge neutrality (see notes)
-    Uses scipy.optimize.root_scalar with brentq implementation
+    Determine the chemical potential by enforcing charge neutrality (see notes).
+
+    Uses scipy.optimize.root_scalar with brentq implementation.
 
     Parameters
     ----------
-    orbs : object(staticKS.Orbitals)
+    orbs : :obj:`staticKS.Orbitals`
         the orbitals object
 
     Returns
@@ -220,11 +220,11 @@ def chem_pot(orbs):
     -----
     Finds the roots of equation
 
-    .. math:: \sum_{nl} (2l+1) f_{fd}(\epsilon_{nl},\beta,\mu) + N_{ub}(\beta,\mu) - N_e = 0.
+    .. math:: \sum_{nl} (2l+1) f_{fd}(\epsilon_{nl},\beta,\mu) +
+        N_{ub}(\beta,\mu) - N_e = 0.
 
     The number of unbound electrons :math:`N_{ub}` depends on the implementation choice.
     """
-
     mu = config.mu
     mu0 = mu  # set initial guess to existing value of chem pot
 
@@ -250,8 +250,9 @@ def chem_pot(orbs):
 
 def f_root_id(mu, eigvals, lbound, nele):
     r"""
-    Functional input for the chemical potential root finding function
-    with the ideal approximation for unbound electrons (see notes)
+    Functional input for the chemical potential root finding function (ideal approx).
+
+    See notes for function returned, the ideal approximation is used for free electrons.
 
     Parameters
     ----------
@@ -274,9 +275,9 @@ def f_root_id(mu, eigvals, lbound, nele):
     -----
     The returned function is
 
-    .. math:: f = \sum_{nl} (2l+1) f_{fd}(\epsilon_{nl},\beta,\mu) + N_{ub}(\beta,\mu) - N_e
+    .. math:: f = \sum_{nl} (2l+1) f_{fd}(\epsilon_{nl},\beta,\mu) +
+        N_{ub}(\beta,\mu) - N_e
     """
-
     # caluclate the contribution from the bound electrons
     if nele != 0:
         occnums = lbound * fermi_dirac(eigvals, mu, config.beta)

--- a/atoMEC/models.py
+++ b/atoMEC/models.py
@@ -227,8 +227,14 @@ class ISModel:
 
         Returns
         -------
-        energy : obj
-            Total energy object
+        output_dict : dict
+            dictionary containing final KS quantities as follows:
+            {
+            `energy` (:obj:`staticKS.Energy`)       : total energy object,
+            `density` (:obj:`staticKS.Density`)     : density object,
+            `potential` (obj:`staticKS.Potential`)  : potential object,
+            `orbitals` (obj:`staticKS.Orbitals`)    : orbitals object
+            }
         """
         # boundary cond, unbound electrons, xc func objects
         config.bc = self.bc

--- a/atoMEC/models.py
+++ b/atoMEC/models.py
@@ -232,8 +232,8 @@ class ISModel:
             {
             `energy` (:obj:`staticKS.Energy`)       : total energy object,
             `density` (:obj:`staticKS.Density`)     : density object,
-            `potential` (obj:`staticKS.Potential`)  : potential object,
-            `orbitals` (obj:`staticKS.Orbitals`)    : orbitals object
+            `potential` (:obj:`staticKS.Potential`)  : potential object,
+            `orbitals` (:obj:`staticKS.Orbitals`)    : orbitals object
             }
         """
         # boundary cond, unbound electrons, xc func objects

--- a/atoMEC/models.py
+++ b/atoMEC/models.py
@@ -198,6 +198,7 @@ class ISModel:
         scf_params={},
         force_bound=[],
         write_info=True,
+        verbosity=0,
     ):
         r"""
         Run a self-consistent calculation to minimize the Kohn-Sham free energy functional.
@@ -277,6 +278,12 @@ class ISModel:
         conv = convergence.SCF(xgrid)
 
         for iscf in range(config.scf_params["maxscf"]):
+
+            # print orbitals and occupations
+            if verbosity == 1:
+                eigs, occs = writeoutput.SCF.write_orb_info(orbs)
+                print("\n" + "Orbital eigenvalues (Ha) :" + "\n\n" + eigs)
+                print("Orbital occupations (2l+1) * f_{nl} :" + "\n\n" + occs)
 
             # construct density
             rho = staticKS.Density(orbs)

--- a/atoMEC/models.py
+++ b/atoMEC/models.py
@@ -39,10 +39,10 @@ class ISModel:
     ----------
     atom : :obj:`Atom`
         The :obj:`Atom` object
-    xfunc : str or int, optional
+    xfunc_id : str or int, optional
         The exchange functional, can be the libxc code or string, or special internal value
         Default : "lda_x"
-    cfunc : str or int, optional
+    cfunc_id : str or int, optional
         The correlation functional, can be the libxc code or string, or special internal value
         Default : "lda_c_pw"
     bc : str, optional

--- a/atoMEC/models.py
+++ b/atoMEC/models.py
@@ -1,3 +1,13 @@
+"""
+Contains models used to compute properties of interest from the Atom object.
+
+So far, the only model implemented is the ISModel. More models will be added in future releases.
+
+Classes
+-------
+ISModel : Ion-sphere type model, static properties such as KS orbitals, density and energy are directly computed
+"""
+
 # import standard packages
 
 # import external packages
@@ -15,6 +25,50 @@ from . import xc
 
 
 class ISModel:
+    """
+    The ISModel represents a particular family of AA models known as ion-sphere models.
+
+    The implementation in atoMEC is based on the model described in the following pre-print:
+    T. J. Callow, E. Kraisler, S. B. Hansen, and A. Cangi, (2021).
+    First-principles derivation and properties of density-functional average-atom models. arXiv preprint arXiv:2103.09928.
+
+    Parameter inputs for this model are related to particular choices of approximation, e.g. boundary conditions
+    or exchange-correlation functional, rather than fundamental physical properties.
+
+    Parameters
+    ----------
+    atom : :obj:`Atom`
+        The :obj:`Atom` object
+    xfunc : str or int, optional
+        The exchange functional, can be the libxc code or string, or special internal value
+        Default : "lda_x"
+    cfunc : str or int, optional
+        The correlation functional, can be the libxc code or string, or special internal value
+        Default : "lda_c_pw"
+    bc : str, optional
+        The boundary condition, can be "dirichlet" or "neumann"
+        Default : "dirichlet"
+    spinpol : bool, optional
+        Whether to run a spin-polarized calculation
+        Default : False
+    spinmag : int, optional
+        The spin-magentization
+        Default: 0 for nele even, 1 for nele odd
+    unbound : str, optional
+        The way in which the unbound electron density is computed
+        Default : "ideal"
+    write_info : bool, optional
+        Writes information about the model parameters
+        Default : True
+
+    Attributes
+    ----------
+    nele_tot: int
+        total number of electrons
+    nele: array_like
+        number of electrons per spin channel (or total if spin unpolarized)
+    """
+
     def __init__(
         self,
         atom,
@@ -26,52 +80,6 @@ class ISModel:
         unbound=config.unbound,
         write_info=True,
     ):
-        """
-        Defines the parameters used for an energy calculation.
-        These are choices for the theoretical model, not numerical parameters for implementation
-
-        Parameters
-        ----------
-        atom : obj
-            The atom object
-        xfunc : Union[str,int], optional
-            The exchange functional, can be the libxc code or string, or special internal value
-            Default : "lda_x"
-        cfunc : Union[str,int], optional
-            The correlation functional, can be the libxc code or string, or special internal value
-            Default : "lda_c_pw"
-        bc : str, optional
-            The boundary condition, can be "dirichlet" or "neumann"
-            Default : "dirichlet"
-        spinpol : bool, optional
-            Whether to run a spin-polarized calculation
-            Default : False
-        spinmag : int, optional
-            The spin-magentization
-            Default: 0 for nele even, 1 for nele odd
-        unbound : str, optional
-            The way in which the unbound electron density is computed
-            Default : "ideal"
-        write_info : bool, optional
-            Writes information about the model parameters
-            Default : True
-        Attributes
-        ----------
-        xfunc : str
-            The (short-hand) name of the exchange functional
-        cfunc : str
-            The (short-hand) name of the correlation functional
-        bc : str
-            The boundary condition
-        spinpol : bool
-            Whether calculation will be spin-polarized
-        nele : ndarray
-            Number of electrons in each spin channel (total if spinpol=False)
-        unbound : str
-            The treatment of unbound electrons
-        info : str
-            Information about all the model parameters
-        """
 
         # Input variables
         self.nele_tot = atom.nele
@@ -88,6 +96,7 @@ class ISModel:
 
     @property
     def spinpol(self):
+        """bool: Whether calculation will be spin-polarized."""
         return self._spinpol
 
     @spinpol.setter
@@ -117,6 +126,7 @@ class ISModel:
 
     @property
     def spinmag(self):
+        """int: the spin magentization (difference in number of up/down spin electrons)."""
         return self._spinmag
 
     @spinmag.setter
@@ -133,6 +143,7 @@ class ISModel:
 
     @property
     def xfunc_id(self):
+        """str: exchange functional shorthand id."""
         return self._xfunc_id
 
     @xfunc_id.setter
@@ -143,6 +154,7 @@ class ISModel:
 
     @property
     def cfunc_id(self):
+        """str: correlation functional shorthand id."""
         return self._cfunc_id
 
     @cfunc_id.setter
@@ -153,6 +165,7 @@ class ISModel:
 
     @property
     def bc(self):
+        """str: the boundary condition for solving the KS equations in a finite sphere."""
         return self._bc
 
     @bc.setter
@@ -162,6 +175,7 @@ class ISModel:
 
     @property
     def unbound(self):
+        """str: the treatment of unbound (free) electrons."""
         return self._unbound
 
     @unbound.setter
@@ -171,15 +185,15 @@ class ISModel:
 
     @property
     def info(self):
+        """str: formatted description of the ISModel attributes."""
         return writeoutput.write_ISModel_data(self)
 
     @writeoutput.timing
     def CalcEnergy(
         self, nmax, lmax, grid_params={}, conv_params={}, scf_params={}, write_info=True
     ):
-
-        """
-        Run a self-consistent calculation to minimize the Kohn-Sham free energy functional
+        r"""
+        Run a self-consistent calculation to minimize the Kohn-Sham free energy functional.
 
         Parameters
         ----------
@@ -216,7 +230,6 @@ class ISModel:
         energy : obj
             Total energy object
         """
-
         # boundary cond, unbound electrons, xc func objects
         config.bc = self.bc
         config.unbound = self.unbound
@@ -302,6 +315,3 @@ class ISModel:
         }
 
         return output_dict
-
-
-# scf_string = self.print_scf_complete(conv_vals)

--- a/atoMEC/models.py
+++ b/atoMEC/models.py
@@ -190,7 +190,14 @@ class ISModel:
 
     @writeoutput.timing
     def CalcEnergy(
-        self, nmax, lmax, grid_params={}, conv_params={}, scf_params={}, write_info=True
+        self,
+        nmax,
+        lmax,
+        grid_params={},
+        conv_params={},
+        scf_params={},
+        force_bound=[],
+        write_info=True,
     ):
         r"""
         Run a self-consistent calculation to minimize the Kohn-Sham free energy functional.
@@ -247,6 +254,9 @@ class ISModel:
         config.conv_params = check_inputs.EnergyCalcs.check_conv_params(conv_params)
         config.scf_params = check_inputs.EnergyCalcs.check_scf_params(scf_params)
 
+        # experimental change
+        config.force_bound = force_bound
+
         # set up the xgrid and rgrid
         xgrid, rgrid = staticKS.log_grid(log(config.r_s))
 
@@ -302,6 +312,10 @@ class ISModel:
             # exit if converged
             if conv_vals["complete"]:
                 break
+
+        # compute final density and energy
+        rho = staticKS.Density(orbs)
+        energy = staticKS.Energy(orbs, rho)
 
         # write final output
         scf_final = writeoutput.SCF().write_final(energy, orbs, rho, conv_vals)

--- a/atoMEC/staticKS.py
+++ b/atoMEC/staticKS.py
@@ -14,6 +14,7 @@ from . import numerov
 from . import mathtools
 from . import xc
 
+
 # the logarithmic grid
 def log_grid(x_r):
     """
@@ -194,8 +195,16 @@ class Orbitals:
 
         for l in range(config.lmax):
             lbound_mat[:, l] = (2.0 / config.spindims) * np.where(
-                eigvals[:, l] < 0, 2 * l + 1.0, 0.0
+                eigvals[:, l] < 0.0, 2 * l + 1.0, 0.0
             )
+
+        # force bound levels if there are convergence issues
+        if config.force_bound != []:
+            for levels in config.force_bound:
+                sp = levels[0]
+                l = levels[1]
+                n = levels[2]
+                lbound_mat[sp, l, n] = (2.0 / config.spindims) * (2 * l + 1.0)
 
         return lbound_mat
 


### PR DESCRIPTION
Errors occur when one of the energy levels changes sign during the SCF cycle (causing oscillatory behaviour as the change in sign changes the way the level is treated).

This allows the user to force certain energy levels to be bound (avoiding the above problem) with the parameter `force_bound` in `models.ISModel.CalcEnergy`. An additional `verbosity` parameter also allows eigenvalues and occupation numbers to be printed after each SCF iteration to get more information about which levels are causing difficulties.