### PR TITLE
Fix convergence issues

### DIFF
--- a/atoMEC/models.py
+++ b/atoMEC/models.py
@@ -183,6 +183,7 @@ class ISModel:
         scf_params={},
         force_bound=[],
         write_info=True,
+        verbosity=0,
     ):
 
         """
@@ -258,6 +259,12 @@ class ISModel:
         conv = convergence.SCF(xgrid)
 
         for iscf in range(config.scf_params["maxscf"]):
+
+            # print orbitals and occupations
+            if verbosity == 1:
+                eigs, occs = writeoutput.SCF.write_orb_info(orbs)
+                print("\n" + "Orbital eigenvalues (Ha) :" + "\n\n" + eigs)
+                print("Orbital occupations (2l+1) * f_{nl} :" + "\n\n" + occs)
 
             # construct density
             rho = staticKS.Density(orbs)

--- a/atoMEC/models.py
+++ b/atoMEC/models.py
@@ -175,7 +175,14 @@ class ISModel:
 
     @writeoutput.timing
     def CalcEnergy(
-        self, nmax, lmax, grid_params={}, conv_params={}, scf_params={}, write_info=True
+        self,
+        nmax,
+        lmax,
+        grid_params={},
+        conv_params={},
+        scf_params={},
+        force_bound=[],
+        write_info=True,
     ):
 
         """
@@ -227,6 +234,9 @@ class ISModel:
         config.grid_params = check_inputs.EnergyCalcs.check_grid_params(grid_params)
         config.conv_params = check_inputs.EnergyCalcs.check_conv_params(conv_params)
         config.scf_params = check_inputs.EnergyCalcs.check_scf_params(scf_params)
+
+        # experimental change
+        config.force_bound = force_bound
 
         # set up the xgrid and rgrid
         xgrid, rgrid = staticKS.log_grid(log(config.r_s))
@@ -283,6 +293,10 @@ class ISModel:
             # exit if converged
             if conv_vals["complete"]:
                 break
+
+        # compute final density and energy
+        rho = staticKS.Density(orbs)
+        energy = staticKS.Energy(orbs, rho)
 
         # write final output
         scf_final = writeoutput.SCF().write_final(energy, orbs, rho, conv_vals)

--- a/atoMEC/models.py
+++ b/atoMEC/models.py
@@ -186,7 +186,7 @@ class ISModel:
         verbosity=0,
     ):
 
-        """
+        r"""
         Run a self-consistent calculation to minimize the Kohn-Sham free energy functional
 
         Parameters
@@ -215,6 +215,15 @@ class ISModel:
             `maxscf`  (``int``)   : maximum number of scf cycles,
             `mixfrac` (``float``) : density mixing fraction
             }
+        force_bound : list of list of ints, optional
+            force certain levels to be bound, for example:
+            `force_bound = [0, 1, 0]`
+            forces the orbital with quantum numbers :math:`\sigma=0,\ l=1,\ n=0` to be always
+            bound even if it has positive energy. This prevents convergence issues.
+        verbosity : int, optional
+            how much information is printed at each SCF cycle.
+            `verbosity=0` prints the total energy and convergence values (default).
+            `verbosity=1` prints the above and the KS eigenvalues and occupations.
         write_info : bool, optional
             prints the scf cycle and final parameters
             defaults to True

--- a/atoMEC/staticKS.py
+++ b/atoMEC/staticKS.py
@@ -14,6 +14,7 @@ from . import numerov
 from . import mathtools
 from . import xc
 
+
 # the logarithmic grid
 def log_grid(x_r):
     """
@@ -194,8 +195,16 @@ class Orbitals:
 
         for l in range(config.lmax):
             lbound_mat[:, l] = (2.0 / config.spindims) * np.where(
-                eigvals[:, l] < 0, 2 * l + 1.0, 0.0
+                eigvals[:, l] < 0.0, 2 * l + 1.0, 0.0
             )
+
+        # force bound levels if there are convergence issues
+        if config.force_bound != []:
+            for levels in config.force_bound:
+                sp = levels[0]
+                l = levels[1]
+                n = levels[2]
+                lbound_mat[sp, l, n] = (2.0 / config.spindims) * (2 * l + 1.0)
 
         return lbound_mat
 

--- a/atoMEC/staticKS.py
+++ b/atoMEC/staticKS.py
@@ -199,7 +199,7 @@ class Orbitals:
             )
 
         # force bound levels if there are convergence issues
-        if config.force_bound != []:
+        if config.force_bound:
             for levels in config.force_bound:
                 sp = levels[0]
                 l = levels[1]


### PR DESCRIPTION
Errors occur when one of the energy levels changes sign during the SCF cycle (causing oscillatory behaviour as the change in sign changes the way the level is treated).

This allows the user to force certain energy levels to be bound (avoiding the above problem) with the parameter `force_bound` in `models.ISModel.CalcEnergy`. An additional `verbosity` parameter also allows eigenvalues and occupation numbers to be printed after each SCF iteration to get more information about which levels are causing difficulties.