### PR TITLE
Fix pydocstyle errors in unitconv and config

### DIFF
--- a/atoMEC/config.py
+++ b/atoMEC/config.py
@@ -1,6 +1,4 @@
-"""
-Configuration file to store global parameters
-"""
+"""Configuration file to store global parameters."""
 
 # physical constants
 mp_g = 1.6726219e-24  # mass of proton in grams

--- a/atoMEC/unitconv.py
+++ b/atoMEC/unitconv.py
@@ -1,6 +1,4 @@
-"""
-Contains unit conversions
-"""
+"""Contains unit conversions."""
 
 cm_to_bohr = 1.889716165e8
 ev_to_ha = 3.6749308136649e-2


### PR DESCRIPTION
Corrects the module docstrings so `pydocstyle` doesn't raise any errors.