### PR TITLE
Tidy up docstrings

### DIFF
--- a/atoMEC/__init__.py
+++ b/atoMEC/__init__.py
@@ -1,22 +1,22 @@
 """
 atoMEC: Average-atom code for matter under extreme conditions.
 
-Copyright (c) 2021 (in alphabetical order), Tim Callow, Attila Cangi, Eli Kraisler
+Copyright (c) 2021 (in alphabetical order), Tim Callow, Attila Cangi, Eli Kraisler.
 All rights reserved.
 
-atoMEC is a python-based average-atom code for simulations of high energy density phenomena such as in warm dense matter.
-Please see the README or the project wiki (https://atomec-project.github.io/atoMEC/) for more information.
+atoMEC is a python-based average-atom code for simulations of high energy density \
+phenomena such as in warm dense matter.
+Please see the README or the project wiki (https://atomec-project.github.io/atoMEC/) \
+for more information.
 
 Classes
 -------
-Atom : the main object for atoMEC calculations, containing information about physical material properties
+* :class:`Atom` : the main object for atoMEC calculations, containing information \
+about physical material properties
 """
 
 # standard libraries
 from math import pi
-
-# external libraries
-import mendeleev
 
 # global imports
 from . import config
@@ -27,10 +27,12 @@ from . import writeoutput
 
 class Atom:
     r"""
-    The principal object in atoMEC calculations which defines the physical material properties.
+    The principal object in atoMEC calculations which defines the physical material \
+    properties.
 
     The `Atom` contains key information about the physical properties of the material
-    such as temperature, density, and charge. It does not contain any information about approximations or choices of model.
+    such as temperature, density, and charge. It does not contain any information \
+    about approximations or choices of model.
 
     Parameters
     ----------

--- a/atoMEC/__init__.py
+++ b/atoMEC/__init__.py
@@ -27,8 +27,7 @@ from . import writeoutput
 
 class Atom:
     r"""
-    The principal object in atoMEC calculations which defines the physical material \
-    properties.
+    The principal object in atoMEC calculations which defines the material properties.
 
     The `Atom` contains key information about the physical properties of the material
     such as temperature, density, and charge. It does not contain any information \

--- a/atoMEC/convergence.py
+++ b/atoMEC/convergence.py
@@ -1,11 +1,13 @@
 """
 Contains classes and functions used to compute and store aspects related to convergence.
 
-So far, the only procedure requring convergence is the static SCF cycle. More will be added in future.
+So far, the only procedure requring convergence is the static SCF cycle. More will \
+be added in future.
 
 Classes
 -------
-SCF : holds the SCF convergence attributes and calculates them for the given cycle
+* :class:`SCF` : holds the SCF convergence attributes and calculates them for the \
+given cycle
 """
 
 # standard libraries
@@ -37,10 +39,11 @@ class SCF:
 
     def check_conv(self, E_free, pot, dens, iscf):
         """
-        Compute and check the changes in energy, integrated density and integrated potential.
+        Compute and check the changes in energy, integrated density and integrated \
+        potential.
 
-        If the convergence tolerances are all simultaneously satisfied, the `complete` variable
-        returns `True` as the SCF cycle is complete.
+        If the convergence tolerances are all simultaneously satisfied, the `complete` \
+        variable returns `True` as the SCF cycle is complete.
 
         Parameters
         ----------

--- a/atoMEC/mathtools.py
+++ b/atoMEC/mathtools.py
@@ -3,20 +3,13 @@ Low-level module containing miscalleneous mathematical functions.
 
 Functions
 ---------
-:func:`normalize_orbs`: normalize KS orbitals within defined sphere
-
-:func:`int_sphere`: integral :math:`4\pi \int \mathrm{d}r r^2 f(r)`
-
-:func:`laplace`: compute the second-order derivative :math:`d^2 y(x) / dx^2`
-
-:func:`fermi_dirac`: compute the Fermi-Dirac occupation function (for given order n)
-
-:func:`fd_int_complete`: compute the complete Fermi-Dirac integral (for given order n)
-
-:func:`chem_pot`: compute the chemical potential by enforcing charge neutrality
-
-:func:`f_root_id`: make root input function for chem_pot with ideal approx for 
-free electrons
+* :func:`normalize_orbs`: normalize KS orbitals within defined sphere
+* :func:`int_sphere`: integral :math:`4\pi \int \mathrm{d}r r^2 f(r)`
+* :func:`laplace`: compute the second-order derivative :math:`d^2 y(x) / dx^2`
+* :func:`fermi_dirac`: compute the Fermi-Dirac occupation function for given order `n`
+* :func:`fd_int_complete`: compute the complete Fermi-Dirac integral for given order `n`
+* :func:`chem_pot`: compute the chemical potential by enforcing charge neutrality
+* :func:`f_root_id`: make root input fn for chem_pot with ideal apprx for free electrons
 """
 
 # standard libraries

--- a/atoMEC/models.py
+++ b/atoMEC/models.py
@@ -1,19 +1,19 @@
 """
 Contains models used to compute properties of interest from the Atom object.
 
-So far, the only model implemented is the ISModel. More models will be added in future releases.
+So far, the only model implemented is the ISModel. More models will be added in future\
+releases.
 
 Classes
 -------
-ISModel : Ion-sphere type model, static properties such as KS orbitals, density and energy are directly computed
+* :class:`ISModel` : Ion-sphere type model, static properties such as KS orbitals, \
+density and energy are directly computed
 """
 
 # import standard packages
 
 # import external packages
-import numpy as np
-from mendeleev import element
-from math import pi, log
+from math import log
 
 # import internal packages
 from . import check_inputs
@@ -28,19 +28,23 @@ class ISModel:
     """
     The ISModel represents a particular family of AA models known as ion-sphere models.
 
-    The implementation in atoMEC is based on the model described in the following pre-print:
-    T. J. Callow, E. Kraisler, S. B. Hansen, and A. Cangi, (2021).
-    First-principles derivation and properties of density-functional average-atom models. arXiv preprint arXiv:2103.09928.
+    The implementation in atoMEC is based on the model described in the pre-print:
 
-    Parameter inputs for this model are related to particular choices of approximation, e.g. boundary conditions
-    or exchange-correlation functional, rather than fundamental physical properties.
+    T. J. Callow, E. Kraisler, S. B. Hansen, and A. Cangi, (2021).
+    First-principles derivation and properties of density-functional \
+    average-atom models. arXiv preprint arXiv:2103.09928.
+
+    Parameter inputs for this model are related to particular choices of approximation,\
+    e.g. boundary conditions or exchange-correlation functional, rather than \
+    fundamental physical properties.
 
     Parameters
     ----------
     atom : :obj:`Atom`
         The :obj:`Atom` object
     xfunc_id : str or int, optional
-        The exchange functional, can be the libxc code or string, or special internal value
+        The exchange functional, can be the libxc code or string, \
+        or special internal value
         Default : "lda_x"
     cfunc_id : str or int, optional
         The correlation functional, can be the libxc code or string, or special internal value
@@ -193,7 +197,8 @@ class ISModel:
         self, nmax, lmax, grid_params={}, conv_params={}, scf_params={}, write_info=True
     ):
         r"""
-        Run a self-consistent calculation to minimize the Kohn-Sham free energy functional.
+        Run a self-consistent calculation to minimize the Kohn-Sham free energy \
+        functional.
 
         Parameters
         ----------

--- a/atoMEC/models.py
+++ b/atoMEC/models.py
@@ -197,8 +197,7 @@ class ISModel:
         self, nmax, lmax, grid_params={}, conv_params={}, scf_params={}, write_info=True
     ):
         r"""
-        Run a self-consistent calculation to minimize the Kohn-Sham free energy \
-        functional.
+        Run a self-consistent calculation to minimize the Kohn-Sham free energy.
 
         Parameters
         ----------

--- a/atoMEC/models.py
+++ b/atoMEC/models.py
@@ -40,8 +40,8 @@ class ISModel:
 
     Parameters
     ----------
-    atom : :obj:`Atom`
-        The :obj:`Atom` object
+    atom : atoMEC.Atom
+        The main atom object
     xfunc_id : str or int, optional
         The exchange functional, can be the libxc code or string, \
         or special internal value

--- a/atoMEC/models.py
+++ b/atoMEC/models.py
@@ -1,7 +1,7 @@
 """
 Contains models used to compute properties of interest from the Atom object.
 
-So far, the only model implemented is the ISModel. More models will be added in future\
+So far, the only model implemented is the ISModel. More models will be added in future
 releases.
 
 Classes
@@ -31,11 +31,11 @@ class ISModel:
     The implementation in atoMEC is based on the model described in the pre-print:
 
     T. J. Callow, E. Kraisler, S. B. Hansen, and A. Cangi, (2021).
-    First-principles derivation and properties of density-functional \
+    First-principles derivation and properties of density-functional
     average-atom models. arXiv preprint arXiv:2103.09928.
 
-    Parameter inputs for this model are related to particular choices of approximation,\
-    e.g. boundary conditions or exchange-correlation functional, rather than \
+    Parameter inputs for this model are related to particular choices of approximation,
+    e.g. boundary conditions or exchange-correlation functional, rather than
     fundamental physical properties.
 
     Parameters
@@ -43,7 +43,7 @@ class ISModel:
     atom : atoMEC.Atom
         The main atom object
     xfunc_id : str or int, optional
-        The exchange functional, can be the libxc code or string, \
+        The exchange functional, can be the libxc code or string,
         or special internal value
         Default : "lda_x"
     cfunc_id : str or int, optional

--- a/atoMEC/numerov.py
+++ b/atoMEC/numerov.py
@@ -1,25 +1,22 @@
-r"""
+"""
 The numerov module handles the routines required to solve the KS equations.
 
 So far, there is only a single implementation which is based on a matrix
 diagonalization. There is an option for parallelizing over the angular
-quantum number :math:`l`.
+quantum number `l`.
 
 Functions
 ---------
-:func:`matrix_solve` : Solve the radial KS equation via matrix diagonalization of
+* :func:`matrix_solve` : Solve the radial KS equation via matrix diagonalization of \
 Numerov's method.
-
-:func:`KS_matsolve_parallel` : Solve the KS matrix diagonalization by parallelizing
+* :func:`KS_matsolve_parallel` : Solve the KS matrix diagonalization by parallelizing \
 over config.ncores.
-
-:func:`KS_matsolve_serial` : Solve the KS matrix diagonalization in serial.
-
-:func:`diag_H` : Diagonalize the Hamiltonian for given input potential.
-
-:func:`update_orbs` : Sort the eigenvalues and functions by ascending energies
-and normalize orbs.
+* :func:`KS_matsolve_serial` : Solve the KS matrix diagonalization in serial.
+* :func:`diag_H` : Diagonalize the Hamiltonian for given input potential.
+* :func:`update_orbs` : Sort the eigenvalues and functions by ascending energies and \
+normalize orbs.
 """
+
 
 # standard libs
 import os

--- a/atoMEC/staticKS.py
+++ b/atoMEC/staticKS.py
@@ -451,7 +451,7 @@ class Potential:
         On the x-grid:
 
         .. math::
-            v_\mathrm{ha}(x) = 4\pi\Big\{\exp(-x)\int_{x0}^x \mathrm{d}x' n(x')\\
+            v_\mathrm{ha}(x) = 4\pi\Big\{\exp(-x)\int_{x0}^x \mathrm{d}x' n(x') \
             \exp(3x') -\int_x^{\log(r_s)} \mathrm{d}x' n(x') \exp(2x') \Big\}
         """
         # initialize v_ha

--- a/atoMEC/xc.py
+++ b/atoMEC/xc.py
@@ -1,19 +1,20 @@
 """
-The xc module handles everything connected to the exchange-correlation energy and potential.
+The xc module handles everything connected to the exchange-correlation energy and \
+potential.
 
 Mostly it sets up inputs and makes appropriate calls to the libxc package.
 
 Classes
 -------
-XCFunc : handles atoMEC-defined functionals (not part of libxc package)
+* :class:`XCFunc` : handles atoMEC-defined functionals (not part of libxc package)
 
 Functions
 ---------
-check_xc_func : checks the xc func input is recognised and valid for atoMEC
-set_xc_func   : initializes the xc functional object
-v_xc          : returns the xc potential on the grid
-E_xc          : returns the xc energy
-calc_xc       : computes the xc energy or potential depending on arguments
+* :func:`check_xc_func` : check the xc func input is recognised and valid for atoMEC
+* :func:`set_xc_func`   : initialize the xc functional object
+* :func:`v_xc`          : return the xc potential on the grid
+* :func:`E_xc`          : return the xc energy
+* :func:`calc_xc`       : compute the xc energy or potential depending on arguments
 """
 
 # standard libs

--- a/atoMEC/xc.py
+++ b/atoMEC/xc.py
@@ -1,8 +1,9 @@
 """
-The xc module handles everything connected to the exchange-correlation energy and
-potential.
+The xc module calculates exchange-correlation energies and potentials.
 
 Mostly it sets up inputs and makes appropriate calls to the libxc package.
+It also includes a class for customized xc-functionals and checks the
+validity of inputs.
 
 Classes
 -------

--- a/atoMEC/xc.py
+++ b/atoMEC/xc.py
@@ -1,5 +1,5 @@
 """
-The xc module handles everything connected to the exchange-correlation energy and \
+The xc module handles everything connected to the exchange-correlation energy and
 potential.
 
 Mostly it sets up inputs and makes appropriate calls to the libxc package.


### PR DESCRIPTION
A few miscalleneous changes to docstrings, including:

* where objects are listed in module docstrings, they are always a bulleted list (for consistency)
* missing or broken links to objects are added
* linelengths trimmed to <=88 characters
* other minor improvements

