### PR TITLE
Corrected the unbound kinetic energy function

### DIFF
--- a/atoMEC/staticKS.py
+++ b/atoMEC/staticKS.py
@@ -680,7 +680,7 @@ class Energy:
         if config.unbound == "ideal":
             E_kin_unbound = 0.0  # initialize
             for i in range(config.spindims):
-                prefac = config.nele[i] * config.sph_vol / (sqrt(2) * pi ** 2)
+                prefac = (2.0 / config.spindims) * config.sph_vol / (sqrt(2) * pi ** 2)
                 E_kin_unbound += prefac * mathtools.fd_int_complete(
                     config.mu[i], config.beta, 3.0
                 )


### PR DESCRIPTION
Prefactor of unbound kinetic energy function was incorrect, this fixes the problem.

Specifically, the factor `nele[i]` denoting the number of electrons in each spin channel has been removed, and the factor `2.0 / config.spindims` has been added. This fix means the unbound kinetic energy agrees with the reference ORCHID code.