### PR TITLE
Fix issue for chemical potential when no electrons in one spin channel

### DIFF
--- a/atoMEC/mathtools.py
+++ b/atoMEC/mathtools.py
@@ -327,13 +327,13 @@ def chem_pot(orbs):
                     x0=mu0[i],
                     args=(orbs.eigvals[i], orbs.lbound[i], config.nele[i]),
                     method="brentq",
-                    bracket=[-40, 40],
+                    bracket=[-100, 100],
                     options={"maxiter": 100},
                 )
                 mu[i] = soln.root
             # in case there are no electrons in one spin channel
             else:
-                mu[i] = np.inf
+                mu[i] = -np.inf
 
     return mu
 
@@ -369,11 +369,8 @@ def f_root_id(mu, eigvals, lbound, nele):
         N_{ub}(\beta,\mu) - N_e
     """
     # caluclate the contribution from the bound electrons
-    if nele != 0:
-        occnums = lbound * fermi_dirac(eigvals, mu, config.beta)
-        contrib_bound = occnums.sum()
-    else:
-        contrib_bound = 0.0
+    occnums = lbound * fermi_dirac(eigvals, mu, config.beta)
+    contrib_bound = occnums.sum()
 
     # now compute the contribution from the unbound electrons
     # this function uses the ideal approximation

--- a/atoMEC/staticKS.py
+++ b/atoMEC/staticKS.py
@@ -356,16 +356,12 @@ class Density:
 
             # unbound density is constant
             for i in range(config.spindims):
-                if config.nele[i] > 1e-5:
-                    prefac = (2.0 / config.spindims) * 1.0 / (sqrt(2) * pi ** 2)
-                    n_ub = prefac * mathtools.fd_int_complete(
-                        config.mu[i], config.beta, 1.0
-                    )
-                    rho_unbound[i] = n_ub
-                    N_unbound[i] = n_ub * config.sph_vol
-                else:
-                    N_unbound[i] = 0.0
-                    rho_unbound[i] = 0.0
+                prefac = (2.0 / config.spindims) * 1.0 / (sqrt(2) * pi ** 2)
+                n_ub = prefac * mathtools.fd_int_complete(
+                    config.mu[i], config.beta, 1.0
+                )
+                rho_unbound[i] = n_ub
+                N_unbound[i] = n_ub * config.sph_vol
 
         unbound = {"rho": rho_unbound, "N": N_unbound}
 


### PR DESCRIPTION
Previously, the chemical potential was set to `+np.inf` when there are no electrons in one spin channel. This was a mistake and led to issues for example in the unbound electron kinetic energy (returning virtually infinite values).

Now it is set to `-np.inf` in this case. Physically I'm not sure this is quite right, but from the point of view of the code it makes everything work smoothly.

