### PR TITLE
Stop CalcEnergy calls in CalcPressure writing new csv files

### DIFF
--- a/atoMEC/models.py
+++ b/atoMEC/models.py
@@ -503,6 +503,8 @@ class ISModel:
             write_info=write_info,
             guess=True,
             guess_pot=energy_output["potential"].v_s,
+            write_density=False,
+            write_potential=False,
         )
         F1 = output1["energy"].F_tot
 
@@ -517,6 +519,8 @@ class ISModel:
             write_info=write_info,
             guess=True,
             guess_pot=energy_output["potential"].v_s,
+            write_density=False,
+            write_potential=False,
         )
         F2 = output2["energy"].F_tot
 


### PR DESCRIPTION
When `CalcPressure` calls `CalcEnergy` it was automatically writing the (slightly modified) density and potential to files, which is undesirable. This hardcodes the `write_density` and `write_potential` variables to `False` when `CalcPressure` calls `CalcEnergy`. 