### PR TITLE
Add `CITATION.cff`

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,15 +8,15 @@ authors:
     given-names: Daniel
   - affiliation: "Center for Advanced Systems Understanding (CASUS), Helmholtz-Zentrum Dresden-Rossendorf e.V. (HZDR)"
     family-names: Tsvetoslavova Stankulova
-    given-names: Ekaterina 
+    given-names: Ekaterina
   - affiliation: "Fritz Haber Center for Molecular Dynamics and Institute of Chemistry, The Hebrew University of Jerusalem"
     family-names: Kraisler
-    given-names: Eli  
+    given-names: Eli
   - affiliation: "Center for Advanced Systems Understanding (CASUS), Helmholtz-Zentrum Dresden-Rossendorf e.V. (HZDR)"
     family-names: Cangi
     given-names: Attila
 cff-version: 1.1.0
-date-released: 2021-08-12
+date-released: 2021-08-13
 keywords:
   - "density-functional-theory"
   - "plasma-physics"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,24 @@
+# YAML 1.2
+authors:
+  - affiliation: "Center for Advanced Systems Understanding (CASUS), Helmholtz-Zentrum Dresden-Rossendorf e.V. (HZDR)"
+    family-names: Callow
+    given-names: Timothy
+  - affiliation: "Center for Advanced Systems Understanding (CASUS), Helmholtz-Zentrum Dresden-Rossendorf e.V. (HZDR)"
+    family-names: Kotik
+    given-names: Daniel
+  - affiliation: "Center for Advanced Systems Understanding (CASUS), Helmholtz-Zentrum Dresden-Rossendorf e.V. (HZDR)"
+    family-names: Cangi
+    given-names: Attila
+cff-version: 1.1.0
+date-released: 2021-08-12
+keywords:
+  - "density-functional-theory"
+  - "plasma-physics"
+  - "electronic-structure"
+  - "atomic-physics"
+  - "warm-dense-matter"
+license: "BSD 3-Clause"
+message: "If you use this software, please cite it using these metadata."
+repository-code: "https://github.com/atomec-project/atoMEC"
+title: atoMEC
+version: 1.0.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -7,6 +7,12 @@ authors:
     family-names: Kotik
     given-names: Daniel
   - affiliation: "Center for Advanced Systems Understanding (CASUS), Helmholtz-Zentrum Dresden-Rossendorf e.V. (HZDR)"
+    family-names: Tsvetoslavova Stankulova
+    given-names: Ekaterina 
+  - affiliation: "Fritz Haber Center for Molecular Dynamics and Institute of Chemistry, The Hebrew University of Jerusalem"
+    family-names: Kraisler
+    given-names: Eli  
+  - affiliation: "Center for Advanced Systems Understanding (CASUS), Helmholtz-Zentrum Dresden-Rossendorf e.V. (HZDR)"
     family-names: Cangi
     given-names: Attila
 cff-version: 1.1.0


### PR DESCRIPTION
See https://citation-file-format.github.io/ for details. GitHub supports citation files, see https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-citation-files. Zenodo added support for `CITATION.cff` as well.

@timcallow Please add all main package contributors as authors to this file (Ekaterina I would suggest to add). I am note sure about Eli and Nathan though.