### PR TITLE
Use bump2version for version update:

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,11 @@
+[bumpversion]
+current_version = 0.1.0
+commit = True
+tag = True
+sign_tags = True
+
+[bumpversion:file:setup.py]
+
+[bumpversion:file:atoMEC/__init__.py]
+
+[bumpversion:file:CITATION.cff]

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -27,4 +27,4 @@ license: "BSD 3-Clause"
 message: "If you use this software, please cite it using these metadata."
 repository-code: "https://github.com/atomec-project/atoMEC"
 title: atoMEC
-version: 1.0.0
+version: 0.1.0

--- a/atoMEC/__init__.py
+++ b/atoMEC/__init__.py
@@ -15,7 +15,7 @@ Classes
 about physical material properties
 """
 
-__version__ = "1.0.0"
+__version__ = "0.1.0"
 
 # standard libraries
 from math import pi

--- a/setup.py
+++ b/setup.py
@@ -7,9 +7,14 @@ with open("README.md") as f:
 with open("LICENSE") as f:
     license = f.read()
 
+extras = {
+    'dev': ['bump2version'],
+    'docs': open('docs/requirements.txt').read().splitlines(),
+}
+
 setup(
     name="atoMEC",
-    version="1.0.0",
+    version="0.1.0",
     description="KS-DFT average-atom code",
     long_description=readme,
     long_description_content_type='text/markdown',
@@ -19,5 +24,6 @@ setup(
     license=license,
     packages=find_packages(exclude=("tests", "docs", "examples")),
     install_requires=open('requirements.txt').read().splitlines(),
+    extras_require=extras,
     python_requires=">=3.6",
 )


### PR DESCRIPTION
We use bump2version for consistent update of version numbers across
different files: `__init__.py`, `CITATION.cff`, `setup.py`.

The command `bumpversion patch` increases the patch number in all files,
commits these changes with an informative message, tags and signs this
commit.

This extra dependency can be installed by `pip install .[dev]`. We also
add to `setup.py` the extra dependencies for building the documentation. These are
now installable via `pip install .[docs]`.

After this merge, we can merge `develop` to master and doing a `bumpversion major` (changes version from `0.1.0` to `1.0.0`). This is our first tag that we will make a release of and can be linked to a DOI.

Closes #66.