### PR TITLE
Add GitHub actions workflow to mirror to CASUS:

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -1,0 +1,16 @@
+name: mirror
+
+on: [push, delete]
+
+jobs:
+  mirror-to-CASUS:
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@v1
+    - name: mirror-repository
+      uses: spyoungtech/mirror-action@v0.4.0
+      with:
+        REMOTE: git@github.com:casus/atoMEC.git
+        GIT_SSH_PRIVATE_KEY: ${{ secrets.GIT_SSH_KEY }}
+        GIT_SSH_NO_VERIFY_HOST: "true"
+        DEBUG: "true"


### PR DESCRIPTION
Pushes new commits automatically to mirror repo of atoMEC within the CASUS organisation.