### PR TITLE
Hardcode final values of kinetic energy density to avoid numerical issues

### DIFF
--- a/atoMEC/staticKS.py
+++ b/atoMEC/staticKS.py
@@ -645,6 +645,9 @@ class Energy:
         # multiply and sum over occupation numbers
         e_kin_dens = np.einsum("ijk,ijkl->l", orbs.occnums, kin_orbs)
 
+        # this is necessary because the Laplacian is not accurate at the boundary
+        e_kin_dens[-3:] = e_kin_dens[-4]
+
         # integrate over sphere
         E_kin_bound = -0.5 * mathtools.int_sphere(e_kin_dens, xgrid)
 

--- a/atoMEC/staticKS.py
+++ b/atoMEC/staticKS.py
@@ -645,7 +645,7 @@ class Energy:
         # multiply and sum over occupation numbers
         e_kin_dens = np.einsum("ijk,ijkl->l", orbs.occnums, kin_orbs)
 
-        # this is necessary because the Laplacian is not accurate at the boundary
+        # FIXME: this is necessary because the Laplacian is not accurate at the boundary
         e_kin_dens[-3:] = e_kin_dens[-4]
 
         # integrate over sphere


### PR DESCRIPTION
There are numerical issues in the computation of the Laplacian which propagate to the kinetic energy density, see #78 .

This avoids the issues by hardcoding the approximate asymptotic value (the last accurate value in the kinetic energy density array) for the final 3 values of the kinetic energy density,