### PR TITLE
Automate PyPI upload

### DIFF
--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -1,6 +1,10 @@
 name: Publish Python 🐍 distributions 📦 to PyPI and TestPyPI
 
-on: push
+on:
+  push:
+    branches:
+      - master
+      - develop
 
 jobs:
   build-n-publish:
@@ -8,7 +12,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
     - name: Check out repository
-      uses: actions/checkout@master
+      uses: actions/checkout@v2
 
     - name: Set up Python 3.8
       uses: actions/setup-python@v2
@@ -32,8 +36,6 @@ jobs:
         .
 
     - name: Publish distribution 📦 to Test PyPI
-      # trigger test publishing run on develop and master branch
-      if: ${{ github.ref == 'refs/heads/master' }} || ${{ github.ref == 'refs/heads/develop' }}
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         password: ${{ secrets.TEST_PYPI_API_TOKEN }}
@@ -42,7 +44,11 @@ jobs:
         skip_existing: true
 
     - name: Publish distribution 📦 to PyPI
+      # trigger only for tagged commits
+      # NB: this is also true for tagged commits on develop!
       if: startsWith(github.ref, 'refs/tags')
+      # NB: another option could be:
+      # if: github.event_name == 'release' && github.event.action == 'created'
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -1,0 +1,49 @@
+name: Publish Python 🐍 distributions 📦 to PyPI and TestPyPI
+
+on: push
+
+jobs:
+  build-n-publish:
+    name: Build and publish Python 🐍 distributions 📦 to PyPI and TestPyPI
+    runs-on: ubuntu-18.04
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@master
+
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.8'
+
+    - name: Install pypa/build
+      run: >-
+        python -m
+        pip install
+        build
+        --user
+
+    - name: Build a binary wheel and a source tarball
+      run: >-
+        python -m
+        build
+        --sdist
+        --wheel
+        --outdir dist/
+        .
+
+    - name: Publish distribution 📦 to Test PyPI
+      # trigger test publishing run on develop and master branch
+      if: ${{ github.ref == 'refs/heads/master' }} || ${{ github.ref == 'refs/heads/develop' }}
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+        repository_url: https://test.pypi.org/legacy/
+        verbose: true
+        skip_existing: true
+
+    - name: Publish distribution 📦 to PyPI
+      if: startsWith(github.ref, 'refs/tags')
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        password: ${{ secrets.PYPI_API_TOKEN }}
+        verbose: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[build-system]
+requires = [
+    "setuptools>=53",
+    "wheel"
+]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
I adjusted the informations given in https://packaging.python.org/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/ and https://github.com/marketplace/actions/pypi-publish to our needs. 
This workflow is triggered to upload a package distribution to [PyPI](https://pypi.org/) for _tagged_ commits on `master` and currently also for tagged commits on `develop`. The latter should change in an improved workflow (it doesn't matter for now since we won't tag commits on `develop`). The workflow also tries to publish to [TestPyPI](https://test.pypi.org/) for _every_ push on `master` and `develop`. This will hopefully ensure to get aware of any problems with regards to package building/publishing as early as possible.