### PR TITLE
Change integral limits in calculation of hartree potential

### DIFF
--- a/atoMEC/staticKS.py
+++ b/atoMEC/staticKS.py
@@ -475,12 +475,12 @@ class Potential:
         for i, x0 in enumerate(xgrid):
 
             # set up 'upper' and 'lower' parts of the xgrid (x<=x0; x>x0)
-            x_u = xgrid[np.where(x0 <= xgrid)]
-            x_l = xgrid[np.where(x0 > xgrid)]
+            x_u = xgrid[np.where(x0 < xgrid)]
+            x_l = xgrid[np.where(x0 >= xgrid)]
 
             # likewise for the density
-            rho_u = rho[np.where(x0 <= xgrid)]
-            rho_l = rho[np.where(x0 > xgrid)]
+            rho_u = rho[np.where(x0 < xgrid)]
+            rho_l = rho[np.where(x0 >= xgrid)]
 
             # now compute the hartree potential
             int_l = exp(-x0) * np.trapz(rho_l * np.exp(3.0 * x_l), x_l)


### PR DESCRIPTION
There was a small mistake in the integral limits for calculating the Hartree potential, see issue #83 for more details. This is corrected.