### PR TITLE
Allow forked repos deploying to GitHub pages:

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -11,6 +11,9 @@ on:
       - documentation
       - develop
 
+permissions:
+  deployments: write  # allows deploying to GitHub pages from forked repositories
+
 jobs:
   python-style-checks:
     runs-on: ubuntu-18.04


### PR DESCRIPTION
This is a workaround, which hopefully works. It would be desirable to skip the deployment step
when opening a PR and only execute this step when a PR actually gets merged.