### PR TITLE
Correct mistake (nmax vs lmax) in eigval initialization

### DIFF
--- a/atoMEC/staticKS.py
+++ b/atoMEC/staticKS.py
@@ -77,7 +77,7 @@ class Orbitals:
         self._eigfuncs = np.zeros(
             (config.spindims, config.lmax, config.nmax, config.grid_params["ngrid"])
         )
-        self._eigvals = np.zeros((config.spindims, config.lmax, config.lmax))
+        self._eigvals = np.zeros((config.spindims, config.lmax, config.nmax))
         self._occnums = np.zeros_like(self._eigvals)
         self._lbound = np.zeros_like(self._eigvals)
 


### PR DESCRIPTION
The `staticKS.Orbitals.eigvals` were being initialized with the wrong dimensions (`lmax` twice instead of `lmax` then `nmax`). It seems this was later corrected by default but would have confused developers. It is fixed now.