### PR TITLE
Fix issue #97 (overwriting data storage folders with `joblib`)

### DIFF
--- a/atoMEC/numerov.py
+++ b/atoMEC/numerov.py
@@ -156,13 +156,15 @@ def KS_matsolve_parallel(T, B, v, xgrid):
             )
 
     # make temporary folder with random name to store arrays
-    joblib_folder = "".join(
-        random.choices(string.ascii_uppercase + string.digits, k=30)
-    )
-    try:
-        os.mkdir(joblib_folder)
-    except FileExistsError:
-        pass
+    while True:
+        try:
+            joblib_folder = "".join(
+                random.choices(string.ascii_uppercase + string.digits, k=30)
+            )
+            os.mkdir(joblib_folder)
+            break
+        except FileExistsError as e:
+            print(e)
 
     # dump and load the large numpy arrays from file
     data_filename_memmap = os.path.join(joblib_folder, "data_memmap")

--- a/atoMEC/numerov.py
+++ b/atoMEC/numerov.py
@@ -21,6 +21,8 @@ Functions
 # standard libs
 import os
 import shutil
+import string
+import random
 
 # external libs
 import numpy as np
@@ -153,8 +155,10 @@ def KS_matsolve_parallel(T, B, v, xgrid):
                 -2 * xgrid
             )
 
-    # make temporary folder to store arrays
-    joblib_folder = "./joblib_memmap"
+    # make temporary folder with random name to store arrays
+    joblib_folder = "".join(
+        random.choices(string.ascii_uppercase + string.digits, k=30)
+    )
     try:
         os.mkdir(joblib_folder)
     except FileExistsError:


### PR DESCRIPTION
This PR is a fix for issue #97. The data folder from which `joblib` reads large arrays is created with a random name so that when multiple jobs are submitted from the same directory, the data written in one job does not overwrite the data in another.