### PR TITLE
Improve sparse diagonalization routine

### DIFF
--- a/atoMEC/check_inputs.py
+++ b/atoMEC/check_inputs.py
@@ -666,9 +666,11 @@ class EnergyCalcs:
         grid_params : dict
             dictionary of grid parameters as follows:
             {
-            `ngrid` (``int``)   : number of grid points,
-            `x0`    (``float``) : LHS grid point takes form
+            `ngrid` (``int``)        : number of grid points,
+            `x0`    (``float``)      : LHS grid point takes form
             :math:`r_0=\exp(x_0)`; :math:`x_0` can be specified
+            `ngrid_coarse` (``int``) : (smaller) number of grid points for estimation
+            of eigenvalues with full diagonalization
             }
 
         Raises
@@ -678,7 +680,7 @@ class EnergyCalcs:
         InputError.ngrid_warning
             if `ngrid` is outside a reasonable convergence range
         """
-        # First assign the keys ngrid and x0 if they are not given
+        # First assign the keys ngrid, x0 and ngrid_coarse if they are not given
         try:
             ngrid = grid_params["ngrid"]
         except KeyError:
@@ -688,6 +690,11 @@ class EnergyCalcs:
             x0 = grid_params["x0"]
         except KeyError:
             x0 = config.grid_params["x0"]
+
+        try:
+            ngrid_coarse = grid_params["ngrid_coarse"]
+        except KeyError:
+            ngrid_coarse = config.grid_params["ngrid_coarse"]
 
         # check that ngrid is an integer
         if not isinstance(ngrid, intc):
@@ -700,13 +707,24 @@ class EnergyCalcs:
         elif ngrid > 5000:
             print(InputWarning.ngrid_warning("high", "expensive"))
 
+        # check that ngrid_coarse is an integer
+        if not isinstance(ngrid_coarse, intc):
+            raise InputError.grid_error("Number of coarse grid points not an integer!")
+        # check that ngrid_coarse is a positive number
+        if ngrid_coarse < 0:
+            raise InputError.grid_error("Number of coarse grid points must be positive")
+        elif ngrid_coarse < 100:
+            print(InputWarning.ngrid_warning("low", "inaccurate"))
+        elif ngrid_coarse > 500:
+            print(InputWarning.ngrid_warning("high", "expensive"))
+
         # check that x0 is reasonable
         if x0 > -3:
             raise InputError.grid_error(
                 "x0 is too high, calculation will likely not converge"
             )
 
-        grid_params = {"ngrid": ngrid, "x0": x0}
+        grid_params = {"ngrid": ngrid, "x0": x0, "ngrid_coarse": ngrid_coarse}
 
         return grid_params
 
@@ -726,9 +744,10 @@ class EnergyCalcs:
         conv_params : dict of floats
             dictionary of convergence parameters as follows:
             {
-            `econv` (``float``) : convergence for total energy,
-            `nconv` (``float``) : convergence for density,
-            `vconv` (``float``) : convergence for electron number
+            `econv` (``float``)  : convergence for total energy,
+            `nconv` (``float``)  : convergence for density,
+            `vconv` (``float``)  : convergence for electron number,
+            `eigtol` (``float``) : tolerance for eigenvalues
             }
 
         Raises
@@ -738,7 +757,7 @@ class EnergyCalcs:
         """
         conv_params = {}
         # loop through the convergence parameters
-        for conv in ["econv", "nconv", "vconv"]:
+        for conv in ["econv", "nconv", "vconv", "eigtol"]:
             # assign value if not given
             try:
                 x_conv = input_params[conv]

--- a/atoMEC/config.py
+++ b/atoMEC/config.py
@@ -12,9 +12,9 @@ unbound = "ideal"  # treatment for unbound electrons
 v_shift = True  # whether to shift the KS potential vertically
 
 # numerical grid for static calculations
-grid_params = {"ngrid": 1000, "x0": -12}
+grid_params = {"ngrid": 1000, "x0": -12, "ngrid_coarse": 300}
 # convergence parameters for static calculations
-conv_params = {"econv": 1.0e-5, "nconv": 1.0e-4, "vconv": 1.0e-4}
+conv_params = {"econv": 1.0e-5, "nconv": 1.0e-4, "vconv": 1.0e-4, "eigtol": 1.0e-4}
 # scf parameters
 scf_params = {"maxscf": 50, "mixfrac": 0.3}
 

--- a/atoMEC/models.py
+++ b/atoMEC/models.py
@@ -211,7 +211,7 @@ class ISModel:
         """str: formatted description of the ISModel attributes."""
         return writeoutput.write_ISModel_data(self)
 
-    # @writeoutput.timing
+    @writeoutput.timing
     def CalcEnergy(
         self,
         nmax,
@@ -241,16 +241,19 @@ class ISModel:
         grid_params : dict, optional
             dictionary of grid parameters as follows:
             {
-            `ngrid` (``int``)   : number of grid points,
-            `x0`    (``float``) : LHS grid point takes form
-            :math:`r_0=\exp(x_0)`; :math:`x_0` can be specified
+            `ngrid` (``int``)        : number of grid points,
+            `x0`    (``float``)      : LHS grid point takes form
+            :math:`r_0=\exp(x_0)`; :math:`x_0` can be specified,
+            `ngrid_coarse` (``int``) : (smaller) number of grid points for estimation
+            of eigenvalues with full diagonalization
             }
         conv_params : dict, optional
             dictionary of convergence parameters as follows:
             {
-            `econv` (``float``) : convergence for total energy,
-            `nconv` (``float``) : convergence for density,
-            `vconv` (``float``) : convergence for electron number
+            `econv` (``float``)  : convergence for total energy,
+            `nconv` (``float``)  : convergence for density,
+            `vconv` (``float``)  : convergence for electron number,
+            `eigtol` (``float``) : convergence for eigenvalues
             }
         scf_params : dict, optional
             dictionary for scf cycle parameters as follows:
@@ -324,7 +327,7 @@ class ISModel:
         else:
             v_init = staticKS.Potential.calc_v_en(xgrid)
         v_s_old = v_init  # initialize the old potential
-        orbs.compute(v_init, init=True)
+        orbs.compute(v_init, init=True, eig_guess=True)
 
         # occupy orbitals
         orbs.occupy()
@@ -368,7 +371,10 @@ class ISModel:
                     v_s[i, :] = v_s[i, :] - v_s[i, -1]
 
             # update the orbitals with the KS potential
-            orbs.compute(v_s)
+            if iscf < 3:
+                orbs.compute(v_s, eig_guess=True)
+            else:
+                orbs.compute(v_s)
             orbs.occupy()
 
             # update old potential
@@ -442,16 +448,19 @@ class ISModel:
         grid_params : dict, optional
             dictionary of grid parameters as follows:
             {
-            `ngrid` (``int``)   : number of grid points,
-            `x0`    (``float``) : LHS grid point takes form
-            :math:`r_0=\exp(x_0)`; :math:`x_0` can be specified
+            `ngrid` (``int``)        : number of grid points,
+            `x0`    (``float``)      : LHS grid point takes form
+            :math:`r_0=\exp(x_0)`; :math:`x_0` can be specified,
+            `ngrid_coarse` (``int``) : (smaller) number of grid points for estimation
+            of eigenvalues with full diagonalization
             }
         conv_params : dict, optional
             dictionary of convergence parameters as follows:
             {
-            `econv` (``float``) : convergence for total energy,
-            `nconv` (``float``) : convergence for density,
-            `vconv` (``float``) : convergence for electron number
+            `econv` (``float``)  : convergence for total energy,
+            `nconv` (``float``)  : convergence for density,
+            `vconv` (``float``)  : convergence for electron number,
+            `eigtol` (``float``) : tolerance for eigenvalues
             }
         scf_params : dict, optional
            dictionary for scf cycle parameters as follows:

--- a/atoMEC/numerov.py
+++ b/atoMEC/numerov.py
@@ -405,7 +405,14 @@ def diag_H(p, T, B, v, xgrid, nmax, bc, eigs_guess, solve_type):
     # use 'shift-invert mode' to find the eigenvalues nearest in magnitude to
     # the estimated lowest eigenvalue from full diagonalization on coarse grid
     if solve_type == "full":
-        evals, evecs = eigs(H, k=nmax, M=B, which="LM", sigma=eigs_guess[p])
+        evals, evecs = eigs(
+            H,
+            k=nmax,
+            M=B,
+            which="LM",
+            tol=config.conv_params["eigtol"],
+            sigma=eigs_guess[p],
+        )
 
         # sort and normalize
         evecs, evals = update_orbs(evecs, evals, xgrid, bc)

--- a/atoMEC/numerov.py
+++ b/atoMEC/numerov.py
@@ -57,7 +57,6 @@ def calc_eigs_min(v, xgrid):
         array containing estimations of the lowest eigenvalue for each value of
         `l` angular quantum number and spin quantum number
     """
-
     # first of all create the coarse xgrid
     xgrid_coarse = np.linspace(xgrid[0], xgrid[-1], config.grid_params["ngrid_coarse"])
 

--- a/atoMEC/staticKS.py
+++ b/atoMEC/staticKS.py
@@ -82,6 +82,7 @@ class Orbitals:
         self._occnums_ub = np.zeros_like(self._eigvals)
         self._lbound = np.zeros_like(self._eigvals)
         self._lunbound = np.zeros_like(self._eigvals)
+        self._eigs_min = np.zeros((config.spindims, config.lmax))
 
     @property
     def eigvals(self):
@@ -152,7 +153,7 @@ class Orbitals:
             self._lunbound = self.make_lunbound(self.eigvals)
         return self._lunbound
 
-    def compute(self, potential, init=False):
+    def compute(self, potential, init=False, eig_guess=False):
         """
         Compute the orbitals and their eigenvalues with the given potential.
 
@@ -173,8 +174,13 @@ class Orbitals:
         # set v to equal the input potential
         v[:] = potential
 
+        if eig_guess:
+            self._eigs_min = numerov.calc_eigs_min(v, self._xgrid)
+
         # solve the KS equations
-        self._eigfuncs, self._eigvals = numerov.matrix_solve(v, self._xgrid)
+        self._eigfuncs, self._eigvals = numerov.matrix_solve(
+            v, self._xgrid, eigs_min_guess=self._eigs_min
+        )
 
         # compute the lbound array
         self._lbound = self.make_lbound(self.eigvals)


### PR DESCRIPTION
This PR is a fix for issue #98. `scipy`'s sparse eigenvalue solver works better (both faster and more reliable) when fewer eigenvalues are requested, so this PR gives a better estimate for the lowest eigenvalue (for a given spin and quantum number `l`), when previously it was just 0 (creating problems for very low lying core states).

The routines to find the eigenvalues now include a "guess" option which performs a full diagonalization of the Hamiltonian (finding all eigenvalues), on a much smaller number of grid points to obtain an initial estimate for the eigenvalues. The lowest eigenvalues are then fed into the sparse matrix diagonalization routine, making we can reduce significantly the number of eigenvalues requested (since before we were finding lots of eigenvalues with energies >0 which were mostly discarded). The full diagonalization is only performed for the first 3 SCF iterations, since after that the estimates should be accurate enough for the rest of the cycle.

Attached are some output files to demonstrate examples of when the old code failed compared to now when it works, and an example of a speed increase.

[Al_new_no_error.txt](https://github.com/atomec-project/atoMEC/files/7538302/Al_new_no_error.txt)
[Al_new_faster.txt](https://github.com/atomec-project/atoMEC/files/7538303/Al_new_faster.txt)
[Al_old_error.txt](https://github.com/atomec-project/atoMEC/files/7538304/Al_old_error.txt)
[Al_old_slow.txt](https://github.com/atomec-project/atoMEC/files/7538305/Al_old_slow.txt)



