### PR TITLE
Accept negative `n_jobs` parameter for `joblib`

### DIFF
--- a/atoMEC/numerov.py
+++ b/atoMEC/numerov.py
@@ -172,7 +172,7 @@ def matrix_solve(v, xgrid, solve_type="full", eigs_min_guess=None):
 
 def KS_matsolve_parallel(T, B, v, xgrid, solve_type, eigs_min_guess):
     """
-    Solve the KS matrix diagonalization by parallelizing over config.ncores.
+    Solve the KS matrix diagonalization by parallelizing over config.numcores.
 
     Parameters
     ----------
@@ -197,6 +197,30 @@ def KS_matsolve_parallel(T, B, v, xgrid, solve_type, eigs_min_guess):
         radial KS wfns
     eigvals : ndarray
         KS eigenvalues
+
+    Notes
+    -----
+    The parallelization is done via the `joblib.Parallel` class of the `joblib` library,
+    see here_ for more information.
+
+    .. _here: https://joblib.readthedocs.io/en/latest/generated/joblib.Parallel.html
+
+    For "best" performance (i.e. exactly one core for each call of the diagonalization
+    routine plus one extra for the "master" node), the number of cores should be chosen
+    as `config.numcores = 1 + config.spindims * config.lmax`. However, if this number is
+    larger than the total number of cores available, performance is hindered.
+
+    Therefore for "good" performance, we can suggest:
+    `config.numcores = max(1 + config.spindimgs * config.lmax, n_avail)`, where
+    `n_avail` is the number of cores available.
+
+    The above is just a guide for how to choose `config.numcores`, there may well
+    be better choices. One example where it might not work is for particularly large
+    numbers of grid points, when the memory required might be too large for a single
+    core.
+
+    N.B. if `config.numcores=-N` then `joblib` detects the number of available cores
+    `n_avail` and parallelizes into `n_avail + 1 - N` separate jobs.
     """
     # compute the number of grid points
     N = np.size(xgrid)

--- a/atoMEC/numerov.py
+++ b/atoMEC/numerov.py
@@ -157,12 +157,13 @@ def matrix_solve(v, xgrid, solve_type="full", eigs_min_guess=None):
     T = -0.5 * p * A
 
     # solve in serial or parallel - serial mostly useful for debugging
-    if config.numcores > 0:
-        eigfuncs, eigvals = KS_matsolve_parallel(
+    if config.numcores == 0:
+        eigfuncs, eigvals = KS_matsolve_serial(
             T, B, v, xgrid, solve_type, eigs_min_guess
         )
+
     else:
-        eigfuncs, eigvals = KS_matsolve_serial(
+        eigfuncs, eigvals = KS_matsolve_parallel(
             T, B, v, xgrid, solve_type, eigs_min_guess
         )
 


### PR DESCRIPTION
As detailed [here](https://joblib.readthedocs.io/en/latest/generated/joblib.Parallel.html), the `joblib` library can accept a negative value for the `n_jobs` parameter and determine how many cores to run on from the maximum number available. This PR updates the code so that if `config.numcores` is negative, the parallel solving routine (rather than the serial one as was done previously) is used. 

The docstring for the `KS_matsolve_parallel` function is also made more detailed.