### PR TITLE
Update `nmax` values in examples

### DIFF
--- a/examples/boundary_comp.py
+++ b/examples/boundary_comp.py
@@ -6,7 +6,7 @@ Compares dirichlet and neumann boundary conditions for Aluminium
 from atoMEC import models, Atom, config
 
 # use parallelization to make things slightly quicker
-config.numcores = -1
+config.numcores = 5
 
 # initialize the atom
 Al = Atom("Al", density=2.7, temp=5, units_temp="eV")
@@ -16,7 +16,7 @@ model = models.ISModel(Al, bc="dirichlet")
 
 # compute the total energy
 dirichlet_out = model.CalcEnergy(
-    25, 4, grid_params={"ngrid": 1000}, scf_params={"mixfrac": 0.7}
+    4, 4, grid_params={"ngrid": 1000}, scf_params={"mixfrac": 0.7}
 )
 energy_dirichlet = dirichlet_out["energy"]
 

--- a/examples/boundary_comp.py
+++ b/examples/boundary_comp.py
@@ -6,7 +6,7 @@ Compares dirichlet and neumann boundary conditions for Aluminium
 from atoMEC import models, Atom, config
 
 # use parallelization to make things slightly quicker
-config.numcores = 5
+config.numcores = -1
 
 # initialize the atom
 Al = Atom("Al", density=2.7, temp=5, units_temp="eV")

--- a/examples/func_compare.py
+++ b/examples/func_compare.py
@@ -15,7 +15,7 @@ atom = Atom("H", radius=4.0, temp=0.01)
 model = models.ISModel(atom, xfunc_id="lda_x", cfunc_id="lda_c_pw", spinpol=True)
 
 # compute the total energy
-lda_out = model.CalcEnergy(20, 3, scf_params={"mixfrac": 0.6})
+lda_out = model.CalcEnergy(2, 2, scf_params={"mixfrac": 0.6})
 energy_lda = lda_out["energy"]
 
 # now change the exchange and correlation functionals
@@ -26,7 +26,7 @@ model.cfunc_id = "None"
 print(model.info)
 
 # compute the total energy again
-clmb_out = model.CalcEnergy(20, 3)
+clmb_out = model.CalcEnergy(2, 2)
 energy_clmb = clmb_out["energy"]
 
 print("Total free energy with LDA :" + str(energy_lda.F_tot))

--- a/examples/pressure_calc.py
+++ b/examples/pressure_calc.py
@@ -20,10 +20,9 @@ model = models.ISModel(Be, bc="dirichlet")
 
 # compute the total energy
 # define the number of levels to scan for
-# note that nmax should be much greater than the actual levels interested in
-# and should be tested for convergence
-nmax = 40
-lmax = 3
+# test these nos for convergence
+nmax = 2
+lmax = 2
 scf_output = model.CalcEnergy(nmax, lmax, grid_params={"ngrid": 2000})
 
 # with the energy output compute the pressure

--- a/examples/simple.py
+++ b/examples/simple.py
@@ -18,10 +18,8 @@ He = Atom(atom_species, radius=r_s, temp=temperature)
 model = models.ISModel(He, bc="neumann")
 
 # compute the total energy
-# define the number of levels to scan for
-# note that nmax should be much greater than the actual levels interested in
-# and should be tested for convergence
-nmax = 20
+# define the number of levels to scan for, should be tested for convergence
+nmax = 2
 lmax = 2
 output = model.CalcEnergy(nmax, lmax, grid_params={"ngrid": 1000})
 


### PR DESCRIPTION
Due to PR #100 we no longer need to request so many eigenvalues from the sparse diagonalization routine. The examples are updated to reflect this.