### PR TITLE
Fix boundary conditions

### DIFF
--- a/atoMEC/numerov.py
+++ b/atoMEC/numerov.py
@@ -324,6 +324,12 @@ def KS_matsolve_serial(T, B, v, xgrid, solve_type, eigs_min_guess):
             # fill potential matrices
             np.fill_diagonal(V_mat, v[i] + 0.5 * (l + 0.5) ** 2 * np.exp(-2 * xgrid))
 
+            # if dirichlet solve on (N-1) x (N-1) grid
+            if config.bc == "dirichlet":
+                T = T[: N - 1, : N - 1]
+                V_mat = V_mat[: N - 1, : N - 1]
+                B = B[: N - 1, : N - 1]
+
             # construct Hamiltonians
             H = T + B * V_mat
 
@@ -331,6 +337,7 @@ def KS_matsolve_serial(T, B, v, xgrid, solve_type, eigs_min_guess):
             # use 'shift-invert mode' to find the eigenvalues nearest in magnitude to
             # the estimated lowest eigenvalue from full diagonalization on coarse grid
             if solve_type == "full":
+
                 eigs_up, vecs_up = eigs(
                     H,
                     k=config.nmax,
@@ -406,9 +413,10 @@ def diag_H(p, T, B, v, xgrid, nmax, bc, eigs_guess, solve_type):
     # construct Hamiltonians
     H = T + B * V_mat
 
+    # if dirichlet solve on (N-1) x (N-1) grid
     if bc == "dirichlet":
-        H = H[:-1, :-1]
-        B = B[:-1, :-1]
+        H = H[: N - 1, : N - 1]
+        B = B[: N - 1, : N - 1]
 
     # we seek the lowest nmax eigenvalues from sparse matrix diagonalization
     # use 'shift-invert mode' to find the eigenvalues nearest in magnitude to

--- a/atoMEC/numerov.py
+++ b/atoMEC/numerov.py
@@ -123,11 +123,15 @@ def matrix_solve(v, xgrid, solve_type="full", eigs_min_guess=None):
     if eigs_min_guess is None:
         eigs_min_guess = np.zeros((config.spindims, config.lmax))
 
+    # define the spacing of the xgrid
+    dx = xgrid[1] - xgrid[0]
+
     if config.bc == "dirichlet":
         N = np.size(xgrid)
+        xgrid_dir = np.linspace(xgrid[0], xgrid[-1] - dx, N)
     elif config.bc == "neumann":
         N = np.size(xgrid) + 1
-        xgrid_neu = np.linspace(xgrid[0], xgrid[-1], N)
+        xgrid_neu = np.linspace(xgrid[0], xgrid[-1] + dx, N)
 
     # extrapolate the potential to one extra pt if neumann bc
     if config.bc == "neumann":
@@ -137,8 +141,6 @@ def matrix_solve(v, xgrid, solve_type="full", eigs_min_guess=None):
         xgrid = xgrid_neu
         v = v_neu
 
-    # define the spacing of the xgrid
-    dx = xgrid[1] - xgrid[0]
     # number of grid points
 
     # Set-up the following matrix diagonalization problem


### PR DESCRIPTION
The matrix diagonalization routine which is used to compute the KS orbitals and their eigenvalues does not give exactly the boundary conditions desired. 

- For the `dirichlet` condition, it fixes the value of the eigenfunctions to zero at the `ngrid +1` grid point; we want them equal to zero at the `ngrid` grid point
- For the `neumann` condition, it correctly sets the derivative to zero at the `ngrid` point, but is unable to resolve the eigenfunction at that point and returns a junk value

Although these only produced very small numerical errors, it is better to fix them. Their behaviour might also be more critical when we consider higher-order properties and more advanced features.

This PR introduces several fixes to ensure the correct behaviour of both bcs. Notably, the dirichlet grid is modified to first ensure the zero occurs at the `ngrid` point. For both bcs, the final point is determined via manual integration of the numerov formula.
