### PR TITLE
Fix small error introduced in PR 106

### DIFF
--- a/atoMEC/numerov.py
+++ b/atoMEC/numerov.py
@@ -150,7 +150,7 @@ def matrix_solve(v, xgrid, solve_type="full", eigs_min_guess=None):
         A[N - 2, N - 1] = 2 * dx ** (-2)
         B[N - 2, N - 1] = 2 * B[N - 2, N - 1]
         A[N - 1, N - 1] = A[N - 1, N - 1] + 1.0 / dx
-        B[N - 1, N - 1] = B[N - 1, N - 1] + dx / 12.0
+        B[N - 1, N - 1] = B[N - 1, N - 1] - dx / 12.0
 
     # construct kinetic energy matrix
     T = -0.5 * p * A


### PR DESCRIPTION
A very small error in the set-up of the neumann matrices was introduced by mistake in PR #106, when I was playing around with the boundary conditions. Actually the reason it got through is because it has an imperceptibly small impact on results (something to do with forward / backward difference formulae for derivatives). Anyhow now it is switched back to how it should be.