### PR TITLE
Fix typo in CITATION.cff (orchid -> orcid)

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,7 +3,7 @@ authors:
   - affiliation: "Center for Advanced Systems Understanding (CASUS), Helmholtz-Zentrum Dresden-Rossendorf e.V. (HZDR)"
     family-names: Callow
     given-names: Timothy
-    orchid: https://orcid.org/0000-0002-4878-3521
+    orcid: https://orcid.org/0000-0002-4878-3521
   - affiliation: "Center for Advanced Systems Understanding (CASUS), Helmholtz-Zentrum Dresden-Rossendorf e.V. (HZDR)"
     family-names: Kotik
     given-names: Daniel
@@ -14,11 +14,11 @@ authors:
   - affiliation: "Fritz Haber Center for Molecular Dynamics and Institute of Chemistry, The Hebrew University of Jerusalem"
     family-names: Kraisler
     given-names: Eli
-    orchid: https://orcid.org/0000-0003-0139-258X
+    orcid: https://orcid.org/0000-0003-0139-258X
   - affiliation: "Center for Advanced Systems Understanding (CASUS), Helmholtz-Zentrum Dresden-Rossendorf e.V. (HZDR)"
     family-names: Cangi
     given-names: Attila
-    orchid: https://orcid.org/0000-0001-9162-262X
+    orcid: https://orcid.org/0000-0001-9162-262X
 cff-version: 1.1.0
 date-released: 2021-12-10
 keywords:


### PR DESCRIPTION
Stupid typo from me, which I only noticed when looking at the new version on zenodo