### PR TITLE
Update zenodo badge to link to generic / latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # atoMEC: Average-Atom Code for Matter under Extreme Conditions
 
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.5205719.svg)](https://doi.org/10.5281/zenodo.5205719)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.5205718.svg)](https://doi.org/10.5281/zenodo.5205718)
 [![docs](https://github.com/atomec-project/atoMEC/actions/workflows/gh-pages.yml/badge.svg)](https://github.com/atomec-project/atoMEC/actions/workflows/gh-pages.yml)
 [![image](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)


### PR DESCRIPTION
Previously the zenodo badge linked to v1.0.0. This updates it to link to the generic DOI (which by default goes to the latest version).