### PR TITLE
Fix issue with CalcPressure function

### DIFF
--- a/atoMEC/models.py
+++ b/atoMEC/models.py
@@ -540,6 +540,9 @@ class ISModel:
         pressureHa = -dFdR * dRdV
         pressureGPa = pressureHa * unitconv.ha_to_gpa
 
+        # convert atom.radius back to its correct value
+        atom.radius = main_rad
+
         pressurestat = "{preamble:30s}: {p_ha:<.6g} Ha / {p_gpa:<.6g} GPa".format(
             preamble="Electronic pressure", p_ha=pressureHa, p_gpa=pressureGPa
         )


### PR DESCRIPTION
The CalcPressure function alters the `Atom.radius` attribute in order to change the volume. But after it should change it back to the physical value, or else if the same `Atom` object is used to compute several pressures whilst changing other variables then it will do so starting with the wrong radius. This PR makes the fix.