### PR TITLE
Use rST admonition directive for a warning box

### DIFF
--- a/atoMEC/postprocess.py
+++ b/atoMEC/postprocess.py
@@ -38,12 +38,14 @@ def calc_IPR_mat(eigfuncs, xgrid):
 
     It is typically used as a localization measure.
 
-    WARNING: the current definition in this version is not mathematically correct.
-    It does not include the proper contribution from the spherical harmonics
-    :math:`|Y_l^m(\theta,\phi)|^4`. This is omitted because it makes little difference
-    to the flavour of the results but complicates things. Currently, this function
-    does not correctly produce the expected limits (even if the spherical harmonic
-    contribution is correctly accounted for). Use at your own peril...
+    .. warning::
+       The current definition in this version is not mathematically correct.
+       It does not include the proper contribution from the spherical harmonics
+       :math:`|Y_l^m(\theta,\phi)|^4`. This is omitted because it makes little
+       difference to the flavour of the results but complicates things. Currently,
+       this function does not correctly produce the expected limits (even if the
+       spherical harmonic contribution is correctly accounted for). Use at your own
+       peril...
     """
     # get the dimensions for the IPR matrix
     spindims = np.shape(eigfuncs)[0]


### PR DESCRIPTION
rST provides several admonition directives, see https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/WritingReST/Admonitions.html.

I've used the warning directive `.. warning::` to put this warning message

![grafik](https://user-images.githubusercontent.com/28047702/150966788-0f7c7daf-b3bc-488f-afc4-8a1ae503f893.png)

in a highlighted box:

![grafik](https://user-images.githubusercontent.com/28047702/150966847-68af15fd-5d97-4d59-9dee-c8e72b883dc5.png)
