### PR TITLE
Avoid pipeline trigger on approved reviews:

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,16 +1,13 @@
 name: docs
 
 on:
-  pull_request_review:
-    types: [submitted,edited]
   pull_request:
     branches:
       - master
       - develop
-      - documentation
   push:
     branches:
-      - documentation
+      - master
       - develop
 
 jobs:
@@ -63,7 +60,7 @@ jobs:
           mv -v docs/_build/html public
 
       - name: Deploy
-        if: ${{ github.event.review.state == 'approved' || github.event_name == 'push' }}
+        if: ${{ github.event_name == 'push' }}
         uses: peaceiris/actions-gh-pages@v3
         with:
           deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}


### PR DESCRIPTION
If the review is approved, a run of the pipeline was triggered but
failed due to insufficient rights from the forked repository. There is
actually no need for an extra run of the pipeline once a review is
approved since a push to master or develop is likely to follow. This
merge/push is done with sufficient rights of the repositories owners.

Fixes #101