### PR TITLE
Add prefix to joblib data folder

### DIFF
--- a/atoMEC/numerov.py
+++ b/atoMEC/numerov.py
@@ -242,8 +242,8 @@ def KS_matsolve_parallel(T, B, v, xgrid, bc, solve_type, eigs_min_guess):
     # make temporary folder with random name to store arrays
     while True:
         try:
-            joblib_folder = "".join(
-                random.choices(string.ascii_uppercase + string.digits, k=30)
+            joblib_folder = "atoMEC_tmpdata_" + "".join(
+                random.choices(string.ascii_uppercase + string.digits, k=20)
             )
             os.mkdir(joblib_folder)
             break


### PR DESCRIPTION
Previously we generated a temporary folder with a totally random name to store large arrays during joblib parallelization. Unfortunately, when a job is interrupted with ctrl-c any such folders remain. This is slightly annoying when several random folders build up (since they must be removed one-by-one...) and might also look strange to someone not aware of their origin. 

Therefore a prefix `atoMEC_tmpdata_` is added to the folder names so they can be deleted in a single command, and to make it clear they are generated by atoMEC.