### PR TITLE
Fix issues with `force_bound`

### DIFF
--- a/atoMEC/config.py
+++ b/atoMEC/config.py
@@ -20,5 +20,8 @@ scf_params = {"maxscf": 50, "mixfrac": 0.3}
 # band parameters for massacrier band model
 band_params = {"nkpts": 50, "de_min": 1e-3}
 
+# forced bound energy levels (default none)
+force_bound = []
+
 # parallelization
 numcores = 0  # defaults to serial

--- a/atoMEC/staticKS.py
+++ b/atoMEC/staticKS.py
@@ -398,7 +398,7 @@ class Orbitals:
 
         # force bound levels if there are convergence issues
 
-        if config.force_bound:
+        if config.force_bound != [] and config.unbound == "ideal":
             for levels in config.force_bound:
                 sp = levels[0]
                 l = levels[1]


### PR DESCRIPTION
Fixes two issues:

- Initializes default `force_bound` in `config.py`; required for some postprocess steps
- Changes incorrect `if force_bound` statement in `staticKS.py` (`force_bound` is a list so it doesn't make sense)