### PR TITLE
Add missing `config` variables to `pressure.py`

### DIFF
--- a/atoMEC/postprocess/pressure.py
+++ b/atoMEC/postprocess/pressure.py
@@ -173,8 +173,9 @@ def stress_tensor(Atom, model, orbs, pot):
        `DOI:10.1103/PhysRevE.99.053201 <https://doi.org/10.1103/PhysRevE.99.053201>`__.
     """
     # retrive the dimensions of the eigenvalues
-    nkpts, spindims, lmax, nmax = np.shape(orbs.eigvals)
-
+    config.band_params["nkpts"], config.spindims, config.lmax, config.nmax, config.grid_params["ngrid"] = np.shape(orbs.eigfuncs)
+    lmax, nmax = config.lmax, config.nmax
+    
     # set the xgrid
     xgrid = orbs._xgrid
 


### PR DESCRIPTION
Previously, if the `stress_tensor` function was called without a prior `CalcEnergy` call, there were errors due to missing `config` variables. This is a problem because postprocessing steps should be independent. Here we fix the issue.