### PR TITLE
Add `Atom` and `model` inputs to `ELFTools` class

### DIFF
--- a/atoMEC/postprocess/localization.py
+++ b/atoMEC/postprocess/localization.py
@@ -32,10 +32,16 @@ class ELFTools:
 
     Parameters
     ----------
+    Atom : atoMEC.Atom
+        the Atom object
+    model : models.ISModel
+        the model object
     orbitals : staticKS.Orbitals
         the orbitals object
     density : staticKS.Density
         the density object
+    method : str, optional
+        the method used for the ELF, "orbitals" or "density"
     """
 
     def __init__(self, Atom, model, orbitals, density, method="orbitals"):

--- a/atoMEC/postprocess/localization.py
+++ b/atoMEC/postprocess/localization.py
@@ -38,7 +38,7 @@ class ELFTools:
         the density object
     """
 
-    def __init__(self, orbitals, density, method="orbitals"):
+    def __init__(self, Atom, model, orbitals, density, method="orbitals"):
         self._orbs = orbitals
         self._density = density
         self._eigfuncs = self._orbs.eigfuncs


### PR DESCRIPTION
This should avoid issues when the `localization.ELFTools` class is called without a prior call to `ISModel.CalcEnergy`