### PR TITLE
Fix error in `CalcPressure` function (attempt #2)

### DIFF
--- a/atoMEC/models.py
+++ b/atoMEC/models.py
@@ -448,6 +448,8 @@ class ISModel:
         self,
         atom,
         energy_output,
+        nmax=None,
+        lmax=None,
         conv_params={},
         scf_params={},
         band_params={},
@@ -504,11 +506,16 @@ class ISModel:
         P_e : float
             electronic pressure in Ha
         """
+        # for backwards compatibility: nmax and lmax will be removed in 2.x
+        if nmax is not None or lmax is not None:
+            sys.exit("nmax and lmax must inherit from CalcEnergy output")
+
         # call the finite diff function
         P_e = pressure.finite_diff(
             atom,
             self,
-            energy_output,
+            energy_output["orbitals"],
+            energy_output["potential"],
             conv_params,
             scf_params,
             force_bound,

--- a/atoMEC/models.py
+++ b/atoMEC/models.py
@@ -11,6 +11,7 @@ Classes
 """
 
 # import standard packages
+import sys
 
 # import external packages
 from math import log


### PR DESCRIPTION
The `ISModel.CalcPressure` function is maintained for backwards compatibility, but had an error in the call to the new `postprocess.pressure.finite_diff` function. This PR resolves that error, and also introduces a check to prevent users trying to change the values of `nmax` and `lmax` from those used in the original calculation.