### PR TITLE
Add codecov to github actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,3 +44,6 @@ jobs:
         
       - name: Run test suite
         run: pipenv run pytest --cov=atoMEC --random-order tests/
+        
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,7 +43,7 @@ jobs:
         run: pipenv run python -m pip install -e .
         
       - name: Run test suite
-        run: pipenv run pytest --cov=atoMEC --random-order tests/
+        run: pipenv run pytest --cov=atoMEC --cov-report=xml --random-order tests/
         
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![PyPI version](https://badge.fury.io/py/atoMEC.svg)](https://badge.fury.io/py/atoMEC)
 [![Python 3.8](https://img.shields.io/badge/python-3.8-blue.svg)](https://www.python.org/downloads/release/python-380/)
+[![codecov](https://codecov.io/gh/atomec-project/atoMEC/branch/develop/graph/badge.svg?token=V66CJJ3KPI)](https://codecov.io/gh/atomec-project/atoMEC)
 
 atoMEC is a python-based average-atom code for simulations of high energy density phenomena such as in warm dense matter.
 It is designed as an open-source and modular python package.


### PR DESCRIPTION
Trying to add Codecov integration to GitHub actions. 

So far, I followed steps GH0-GH2 [here](https://docs.codecov.com/docs/github-tutorial).

Seems we should first merge this branch into develop, according to the guide linked above. Then we can add more things like minimum coverage checks and a badge.