### PR TITLE
Fix and update broken mirror workflow:

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -4,13 +4,15 @@ on: [push, delete]
 
 jobs:
   mirror-to-CASUS:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v1
-    - name: mirror-repository
-      uses: spyoungtech/mirror-action@v0.4.0
+    - uses: actions/checkout@v3
       with:
-        REMOTE: git@github.com:casus/atoMEC.git
+        fetch-depth: 0
+    - name: mirror-repository
+      uses: spyoungtech/mirror-action@v0.6.0
+      with:
+        REMOTE: 'ssh://git@github.com/casus/atoMEC.git'
         GIT_SSH_PRIVATE_KEY: ${{ secrets.GIT_SSH_KEY }}
         GIT_SSH_NO_VERIFY_HOST: "true"
         DEBUG: "true"


### PR DESCRIPTION
- Update Ubuntu environment (18.04 is deprecated)
- Update checkout action (Node.js 12 actions are deprecated)
- Update mirror action (0.4.0 -> 0.6.0): this fixes the mirror workflow
- Change fetch depth to 0: Default is 1, but with 0 we get all history for all branches and tags.