### PR TITLE
Add a function to check nmax and lmax are big enough

### DIFF
--- a/atoMEC/check_inputs.py
+++ b/atoMEC/check_inputs.py
@@ -752,10 +752,11 @@ class EnergyCalcs:
         conv_params : dict of floats
             dictionary of convergence parameters as follows:
             {
-            `econv` (``float``)  : convergence for total energy,
-            `nconv` (``float``)  : convergence for density,
-            `vconv` (``float``)  : convergence for electron number,
-            `eigtol` (``float``) : tolerance for eigenvalues
+            `econv` (``float``)   : convergence for total energy,
+            `nconv` (``float``)   : convergence for density,
+            `vconv` (``float``)   : convergence for electron number,
+            `eigtol` (``float``)  : tolerance for eigenvalues,
+            `bandtol` (``float``) : tolerance for n(l)max warning
             }
 
         Raises
@@ -765,7 +766,7 @@ class EnergyCalcs:
         """
         conv_params = {}
         # loop through the convergence parameters
-        for conv in ["econv", "nconv", "vconv", "eigtol"]:
+        for conv in ["econv", "nconv", "vconv", "eigtol", "bandtol"]:
             # assign value if not given
             try:
                 x_conv = input_params[conv]

--- a/atoMEC/check_inputs.py
+++ b/atoMEC/check_inputs.py
@@ -1174,7 +1174,19 @@ class InputWarning:
         return warning
 
     def norbs_warning(quantum_num):
+        """
+        Warn if either nmax or lmax is too low for convergence.
 
+        Parameters
+        ----------
+        quantum_num : str
+            lmax or nmax
+
+        Returns
+        -------
+        warning : str
+            full error message
+        """
         warning = (
             "Warning: "
             + quantum_num

--- a/atoMEC/check_inputs.py
+++ b/atoMEC/check_inputs.py
@@ -355,7 +355,7 @@ class Atom:
         # radius in cm
         rad_cm = radius / unitconv.cm_to_bohr
         # volume in cm
-        vol_cm = (4.0 * pi * rad_cm ** 3) / 3.0
+        vol_cm = (4.0 * pi * rad_cm**3) / 3.0
         # atomic mass in g
         mass_g = config.mp_g * atom.at_mass
         # density in g cm^-3
@@ -1170,4 +1170,16 @@ class InputWarning:
             + "Suggested grid range is between 1000-5000 but should be tested wrt"
             " convergence \n"
         )
+        return warning
+
+    def norbs_warning(quantum_num):
+
+        warning = (
+            "Warning: "
+            + quantum_num
+            + " appears to be too low. Proceeding anyway, but suggest to increase "
+            + quantum_num
+            + " and restart calculation"
+        )
+
         return warning

--- a/atoMEC/config.py
+++ b/atoMEC/config.py
@@ -14,7 +14,13 @@ v_shift = True  # whether to shift the KS potential vertically
 # numerical grid for static calculations
 grid_params = {"ngrid": 1000, "x0": -12, "ngrid_coarse": 300}
 # convergence parameters for static calculations
-conv_params = {"econv": 1.0e-5, "nconv": 1.0e-4, "vconv": 1.0e-4, "eigtol": 1.0e-4}
+conv_params = {
+    "econv": 1.0e-5,
+    "nconv": 1.0e-4,
+    "vconv": 1.0e-4,
+    "eigtol": 1.0e-4,
+    "bandtol": 1.0e-3,
+}
 # scf parameters
 scf_params = {"maxscf": 50, "mixfrac": 0.3}
 # band parameters for massacrier band model

--- a/atoMEC/models.py
+++ b/atoMEC/models.py
@@ -259,7 +259,8 @@ class ISModel:
             `econv` (``float``)  : convergence for total energy,
             `nconv` (``float``)  : convergence for density,
             `vconv` (``float``)  : convergence for electron number,
-            `eigtol` (``float``) : convergence for eigenvalues
+            `eigtol` (``float``) : convergence for eigenvalues,
+            `bandtol` (``float``) : tolerance for n(l)max warning
             }
         scf_params : dict, optional
             dictionary for scf cycle parameters as follows:

--- a/atoMEC/staticKS.py
+++ b/atoMEC/staticKS.py
@@ -39,6 +39,7 @@ from . import config
 from . import numerov
 from . import mathtools
 from . import xc
+from . import check_inputs
 
 # from . import writeoutput
 
@@ -135,6 +136,12 @@ class Orbitals:
     def occnums_w(self):
         r"""ndarray: Weighted KS occupation numbers."""
         self._occnums_w = self.occnums * self.occ_weight
+        # check if more bands are needed
+        norbs_ok, lorbs_ok = self.check_orbs(self._occnums_w)
+        if not norbs_ok:
+            print(check_inputs.InputWarning.norbs_warning("nmax"))
+        if not lorbs_ok:
+            print(check_inputs.InputWarning.norbs_warning("lmax"))
         return self._occnums_w
 
     @property
@@ -596,6 +603,21 @@ class Orbitals:
         # sort the array
         e_tot_arr = np.sort(e_tot_arr)
         return e_tot_arr
+
+    @staticmethod
+    def check_orbs(occnums_w, threshold=1e-3):
+        lorbs_ok = True
+        norbs_ok = True
+        # sum over the first two dimensions (spin and kpts)
+        occs_sum = np.sum(occnums_w, axis=(0, 1))
+        # check the l dimension
+        occs_l = occs_sum[:, -1]
+        if max(occs_l) > threshold:
+            lorbs_ok = False
+        occs_n = occs_sum[-1, :]
+        if max(occs_n) > threshold:
+            norbs_ok = False
+        return lorbs_ok, norbs_ok
 
 
 class Density:

--- a/atoMEC/staticKS.py
+++ b/atoMEC/staticKS.py
@@ -137,7 +137,9 @@ class Orbitals:
         r"""ndarray: Weighted KS occupation numbers."""
         self._occnums_w = self.occnums * self.occ_weight
         # check if more bands are needed
-        norbs_ok, lorbs_ok = self.check_orbs(self._occnums_w)
+        norbs_ok, lorbs_ok = self.check_orbs(
+            self._occnums_w, config.conv_params["bandtol"]
+        )
         if not norbs_ok:
             print(check_inputs.InputWarning.norbs_warning("nmax"))
         if not lorbs_ok:
@@ -605,7 +607,7 @@ class Orbitals:
         return e_tot_arr
 
     @staticmethod
-    def check_orbs(occnums_w, threshold=1e-3):
+    def check_orbs(occnums_w, threshold):
         lorbs_ok = True
         norbs_ok = True
         # sum over the first two dimensions (spin and kpts)

--- a/atoMEC/staticKS.py
+++ b/atoMEC/staticKS.py
@@ -608,6 +608,25 @@ class Orbitals:
 
     @staticmethod
     def check_orbs(occnums_w, threshold):
+        r"""Check the values of nmax and lmax are sufficient.
+
+        Finds the values of the occupations of the final orbitals in lmax
+        and nmax directions. If either is above the threshold, returns False
+        (which triggers a warning elsewhere).
+
+        Parameters
+        ----------
+        occnums_w : np.ndarray
+            weighted orbital occupations
+        threshold : float
+            the threshold occupation number at which to trigger a warning
+
+        Returns
+        -------
+        norbs_ok, lorbs_ok : tuple of bools
+            whether the values of nmax and lmax are sufficient
+
+        """
         lorbs_ok = True
         norbs_ok = True
         # sum over the first two dimensions (spin and kpts)

--- a/tests/pressure_test.py
+++ b/tests/pressure_test.py
@@ -111,6 +111,7 @@ class TestPressure:
             3,
             scf_params={"maxscf": 5},
             grid_params={"ngrid": 1000},
+            band_params={"nkpts": 50},
             verbosity=1,
         )
 


### PR DESCRIPTION
A utility function to check that the user chosen values of `nmax` and `lmax` are big enough (to ensure convergence)