### PR TITLE
Update pressure tests and fix sqrt grid error in Numerov

### DIFF
--- a/atoMEC/numerov.py
+++ b/atoMEC/numerov.py
@@ -494,9 +494,11 @@ class Solver:
             K = np.zeros((N, nmax))
             for n in range(nmax):
                 if self.grid_type == "log":
-                    K[:, n] = -2 * np.exp(2 * xgrid) * (V_mat.diagonal() - evals.real[n])
+                    K[:, n] = (
+                        -2 * np.exp(2 * xgrid) * (V_mat.diagonal() - evals.real[n])
+                    )
                 else:
-                    K[:, n] = 8 *xgrid**2 * (V_mat.diagonal() - evals.real[n])
+                    K[:, n] = 8 * xgrid**2 * (V_mat.diagonal() - evals.real[n])
             evecs, evals = self.update_orbs(evecs, evals, xgrid, bc, K, self.grid_type)
 
             return evecs, evals

--- a/atoMEC/numerov.py
+++ b/atoMEC/numerov.py
@@ -493,7 +493,10 @@ class Solver:
             # sort and normalize
             K = np.zeros((N, nmax))
             for n in range(nmax):
-                K[:, n] = -2 * np.exp(2 * xgrid) * (V_mat.diagonal() - evals.real[n])
+                if self.grid_type == "log":
+                    K[:, n] = -2 * np.exp(2 * xgrid) * (V_mat.diagonal() - evals.real[n])
+                else:
+                    K[:, n] = 8 *xgrid**2 * (V_mat.diagonal() - evals.real[n])
             evecs, evals = self.update_orbs(evecs, evals, xgrid, bc, K, self.grid_type)
 
             return evecs, evals

--- a/tests/pressure_test_log.py
+++ b/tests/pressure_test_log.py
@@ -181,6 +181,7 @@ class TestPressure:
         energy = SCF_input["SCF_out"]["energy"]
         rho = SCF_input["SCF_out"]["density"]
         orbs = SCF_input["SCF_out"]["orbitals"]
+        pot = SCF_input["SCF_out"]["potential"]
 
         P_e = h2g * pressure.virial(
             SCF_input["Atom"],
@@ -188,6 +189,7 @@ class TestPressure:
             energy,
             rho,
             orbs,
+            pot,
             use_correction=use_correction,
         )
 

--- a/tests/pressure_test_sqrt.py
+++ b/tests/pressure_test_sqrt.py
@@ -175,6 +175,7 @@ class TestPressure:
         energy = SCF_input["SCF_out"]["energy"]
         rho = SCF_input["SCF_out"]["density"]
         orbs = SCF_input["SCF_out"]["orbitals"]
+        pot = SCF_input["SCF_out"]["potential"]
 
         P_e = h2g * pressure.virial(
             SCF_input["Atom"],
@@ -182,6 +183,7 @@ class TestPressure:
             energy,
             rho,
             orbs,
+            pot,
             use_correction=use_correction,
         )
 


### PR DESCRIPTION
Due to a mix up this PR actually fixes two separate issues:
- Pressure tests include potential for virial method
- For final grid point propagation, fixed for sqrt grid