### PR TITLE
Fix errors that caused float64 to always be used

### DIFF
--- a/atoMEC/numerov.py
+++ b/atoMEC/numerov.py
@@ -686,7 +686,9 @@ class Solver:
         )
 
         # reshape the eigenfucntions
-        eigfuncs_e = eigfuncs_flat.reshape((nkpts, spindims, lmax, nmax, N))
+        eigfuncs_e = eigfuncs_flat.reshape((nkpts, spindims, lmax, nmax, N)).astype(
+            self.fp
+        )
 
         return eigfuncs_e
 

--- a/atoMEC/staticKS.py
+++ b/atoMEC/staticKS.py
@@ -63,7 +63,9 @@ def log_grid(x_r):
         The grids in logarithmic (x) and real (r) space
     """
     # grid in logarithmic co-ordinates
-    xgrid = np.linspace(config.grid_params["x0"], x_r, config.grid_params["ngrid"])
+    xgrid = np.linspace(
+        config.grid_params["x0"], x_r, config.grid_params["ngrid"], dtype=config.fp
+    )
     # grid in real space co-ordinates
     rgrid = np.exp(xgrid)
 
@@ -324,7 +326,10 @@ class Orbitals:
 
         # make the energy band array
         e_arr = np.linspace(
-            self.eigvals_min, self.eigvals_max, config.band_params["nkpts"]
+            self.eigvals_min,
+            self.eigvals_max,
+            config.band_params["nkpts"],
+            dtype=config.fp,
         )
 
         # propagate the numerov equation

--- a/atoMEC/staticKS.py
+++ b/atoMEC/staticKS.py
@@ -63,9 +63,7 @@ def log_grid(x_r):
         The grids in logarithmic (x) and real (r) space
     """
     # grid in logarithmic co-ordinates
-    xgrid = np.linspace(
-        config.grid_params["x0"], x_r, config.grid_params["ngrid"], dtype=config.fp
-    )
+    xgrid = np.linspace(config.grid_params["x0"], x_r, config.grid_params["ngrid"])
     # grid in real space co-ordinates
     rgrid = np.exp(xgrid)
 


### PR DESCRIPTION
Some arrays were still hard-coded to float64 precision. This PR fixes that problem.