### PR TITLE
Small improvements to tests

### DIFF
--- a/tests/boundary_conditions_test.py
+++ b/tests/boundary_conditions_test.py
@@ -76,3 +76,10 @@ class TestBcs:
         # extract the total free energy
         F_tot = output["energy"].F_tot
         return F_tot
+
+
+if __name__ == "__main__":
+    config.numcores = -1
+    print("dirichlet = ", TestBcs._run("dirichlet"))
+    print("neumann = ", TestBcs._run("neumann"))
+    print("bands = ", TestBcs._run("bands"))

--- a/tests/conductivity_test.py
+++ b/tests/conductivity_test.py
@@ -236,20 +236,20 @@ class TestConductivity:
 
 
 if __name__ == "__main__":
+    config.numcores = -1
     SCF_out = TestConductivity._run_SCF()
     print(TestConductivity._run_cond_tot(SCF_out, "cc", (1, 0)))
-    print(TestConductivity._run_cond_tot(SCF_out, "tt", (1, 0)))
-    print(TestConductivity._run_cond_tot(SCF_out, "cv", (1, 0)))
-    print(TestConductivity._run_cond_tot(SCF_out, "vv", (1, 0)))
     print(TestConductivity._run_cond_tot(SCF_out, "cc", (3, 1)))
+    print(TestConductivity._run_cond_tot(SCF_out, "tt", (1, 0)))
     print(TestConductivity._run_cond_tot(SCF_out, "tt", (3, 1)))
-    print(TestConductivity._run_cond_tot(SCF_out, "cv", (3, 1)))
+    print(TestConductivity._run_cond_tot(SCF_out, "vv", (1, 0)))
     print(TestConductivity._run_cond_tot(SCF_out, "vv", (3, 1)))
+    print(TestConductivity._run_cond_tot(SCF_out, "cv", (1, 0)))
+    print(TestConductivity._run_cond_tot(SCF_out, "cv", (3, 1)))
+    print(TestConductivity._run_int_calc(4))
+    print(TestConductivity._run_int_calc(2))
     print(TestConductivity._run_sum_rule(SCF_out))
     print(TestConductivity._run_prop(SCF_out, "sig_vv"))
     print(TestConductivity._run_prop(SCF_out, "sig_cv"))
     print(TestConductivity._run_prop(SCF_out, "N_tot"))
     print(TestConductivity._run_prop(SCF_out, "N_free"))
-    print(TestConductivity._run_int_calc(2))
-    print(TestConductivity._run_int_calc(4))
-    print(TestConductivity._run_sum_rule(SCF_out))

--- a/tests/energy_alt_test.py
+++ b/tests/energy_alt_test.py
@@ -85,5 +85,6 @@ class TestEnergyAlt:
 
 
 if __name__ == "__main__":
+    config.numcores = -1
     print("ideal energy = ", TestEnergyAlt._run("ideal"))
     print("quantum energy = ", TestEnergyAlt._run("quantum"))

--- a/tests/exceptions_test.py
+++ b/tests/exceptions_test.py
@@ -84,11 +84,7 @@ class TestModel:
 
     @pytest.mark.parametrize(
         "xc_input",
-        [
-            (5.0),
-            ("lca"),
-            ("gga_z_pbc")
-        ],
+        [(5.0), ("lca"), ("gga_z_pbc")],
     )
     def test_xc(self, xc_input):
         """Test the exchange-correlation (xc) input."""
@@ -177,7 +173,6 @@ class TestCalcEnergy:
         model = models.ISModel(atom)
 
         with pytest.raises(SystemExit):
-
             model.CalcEnergy(3, 3, grid_params=grid_input)
 
     @pytest.mark.parametrize(
@@ -193,7 +188,6 @@ class TestCalcEnergy:
         model = models.ISModel(atom)
 
         with pytest.raises(SystemExit):
-
             model.CalcEnergy(3, 3, conv_params=conv_input)
 
     @pytest.mark.parametrize(
@@ -211,7 +205,6 @@ class TestCalcEnergy:
         model = models.ISModel(atom)
 
         with pytest.raises(SystemExit):
-
             model.CalcEnergy(3, 3, scf_params=scf_input)
 
     @pytest.mark.parametrize(
@@ -229,5 +222,4 @@ class TestCalcEnergy:
         model = models.ISModel(atom, bc="bands", unbound="quantum")
 
         with pytest.raises(SystemExit):
-
             model.CalcEnergy(3, 3, band_params=bands_input)

--- a/tests/functionals_test.py
+++ b/tests/functionals_test.py
@@ -41,6 +41,7 @@ class TestFuncs:
         """Check the free energy for different functionals."""
         # parallel
         config.numcores = -1
+        config.fp = np.float32
 
         assert np.isclose(self._run(test_input), expected, atol=accuracy)
 
@@ -83,6 +84,7 @@ class TestFuncs:
             unbound="quantum",
             xfunc_id=xfunc_id,
             cfunc_id=cfunc_id,
+            bc="bands",
         )
 
         # run the SCF calculation
@@ -91,15 +93,20 @@ class TestFuncs:
             6,
             scf_params={"maxscf": 5, "mixfrac": 0.3},
             grid_params={"ngrid": 1000},
+            grid_type="sqrt",
         )
+
+        print(output["orbitals"].eigfuncs.dtype)
 
         # extract the total free energy
         F_tot = output["energy"].F_tot
         return F_tot
 
 
-# if __name__ == "__main__":
-#     print("lda=", Test_funcs().run("lda"))
-#     print("gdsmfb=", Test_funcs().run("gdsmfb"))
-#     print("no_xc=", Test_funcs().run("no_xc"))
-#     print("no_hxc=", Test_funcs().run("no_hxc"))
+if __name__ == "__main__":
+    config.numcores = -1
+    print("lda=", TestFuncs()._run("lda"))
+    print("gdsmfb=", TestFuncs()._run("gdsmfb"))
+    print("no_xc=", TestFuncs()._run("no_xc"))
+    print("no_hxc=", TestFuncs()._run("no_hxc"))
+    print("pbe=", TestFuncs()._run("gga"))

--- a/tests/functionals_test.py
+++ b/tests/functionals_test.py
@@ -41,7 +41,6 @@ class TestFuncs:
         """Check the free energy for different functionals."""
         # parallel
         config.numcores = -1
-        config.fp = np.float32
 
         assert np.isclose(self._run(test_input), expected, atol=accuracy)
 
@@ -84,7 +83,6 @@ class TestFuncs:
             unbound="quantum",
             xfunc_id=xfunc_id,
             cfunc_id=cfunc_id,
-            bc="bands",
         )
 
         # run the SCF calculation
@@ -93,10 +91,7 @@ class TestFuncs:
             6,
             scf_params={"maxscf": 5, "mixfrac": 0.3},
             grid_params={"ngrid": 1000},
-            grid_type="sqrt",
         )
-
-        print(output["orbitals"].eigfuncs.dtype)
 
         # extract the total free energy
         F_tot = output["energy"].F_tot

--- a/tests/localization_test.py
+++ b/tests/localization_test.py
@@ -13,11 +13,11 @@ import numpy as np
 
 
 # expected values and tolerance
+epdc_orbs_expected = 9.2269
+epdc_dens_expected = 3.5304
 orbitals_expected = 1.0889
 density_expected = 2.1496
 IPR_expected = 78.2107
-epdc_orbs_expected = 9.2269
-epdc_dens_expected = 3.5304
 accuracy = 0.01
 
 
@@ -218,6 +218,7 @@ class TestLocalization:
 
 
 if __name__ == "__main__":
+    config.numcores = -1
     SCF_spin_out = TestLocalization._run_SCF(True)
     SCF_no_spin_out = TestLocalization._run_SCF(False)
     print(TestLocalization._run_epdc(SCF_spin_out, "orbitals", True))

--- a/tests/spin_test.py
+++ b/tests/spin_test.py
@@ -57,7 +57,7 @@ class TestSpin:
             unbound="quantum",
             bc="bands",
             xfunc_id="gga_x_pbe",
-            cfunc_id="gga_c_pbe"
+            cfunc_id="gga_c_pbe",
         )
 
         # run the SCF calculation
@@ -75,5 +75,6 @@ class TestSpin:
 
 
 if __name__ == "__main__":
+    config.numcores = -1
     print("singlet energy = ", TestSpin._run(0))
     print("triplet energy = ", TestSpin._run(2))

--- a/tests/unbound_test.py
+++ b/tests/unbound_test.py
@@ -59,4 +59,5 @@ class TestUnbound:
 
 
 if __name__ == "__main__":
+    config.numcores = -1
     print(TestUnbound._run())


### PR DESCRIPTION
For debugging and checking it's often easier to run `python test_x.py` rather than `pytest text_x.py`. This PR ensures all tests will run with the first option