### PR TITLE
Explicitly use diagonal matrices in numerov solver

### DIFF
--- a/atoMEC/numerov.py
+++ b/atoMEC/numerov.py
@@ -204,11 +204,7 @@ class Solver:
         else:
             p_sparse = diags([0.25 * xgrid**-2], offsets=[0], dtype=dtype)
 
-        A_dense = A_sparse.todense()
-        B_dense = B_sparse.todense()
-
         # construct kinetic energy matrix
-        T = -0.5 * p @ A
         T_sparse = -0.5 * p_sparse @ A_sparse
 
         # solve in serial or parallel - serial mostly useful for debugging
@@ -776,9 +772,22 @@ class Solver:
         return Psi_norm
 
     @staticmethod
-    def mat_convert_dirichlet(mat):
+    def mat_convert_dirichlet(diag_mat):
+        """
+        Truncate a scipy diags matrix from (N,N) to (N-1, N-1).
+
+        Parameters
+        ----------
+        diag_mat : scipy.sparse.diags object
+            diagonal matrix to truncate
+
+        Returns
+        -------
+        diag_mat : scipy.sparse.diags object
+            truncated diagonal matrix
+        """
         # Convert to a dense matrix
-        dense_mat = mat.todense()
+        dense_mat = diag_mat.todense()
 
         # Truncate the dense matrix
         dense_mat_truncated = dense_mat[:-1, :-1]
@@ -789,6 +798,8 @@ class Solver:
         lower_diag = np.diag(dense_mat_truncated, k=-1)
 
         # Create a new diags matrix with the extracted diagonals
-        mat_truncated = diags([main_diag, upper_diag, lower_diag], offsets=[0, 1, -1])
+        diag_mat_truncated = diags(
+            [main_diag, upper_diag, lower_diag], offsets=[0, 1, -1]
+        )
 
-        return mat_truncated
+        return diag_mat_truncated

--- a/atoMEC/numerov.py
+++ b/atoMEC/numerov.py
@@ -18,7 +18,6 @@ import shutil
 import string
 import random
 import warnings
-import time
 
 # external libs
 import numpy as np

--- a/atoMEC/numerov.py
+++ b/atoMEC/numerov.py
@@ -33,7 +33,6 @@ from joblib import Parallel, delayed, dump, load
 # internal libs
 from . import config
 from . import mathtools
-from . import writeoutput
 
 # from . import writeoutput
 
@@ -382,8 +381,6 @@ class Solver:
         eigvals = np.zeros((config.spindims, config.lmax, config.nmax), dtype=dtype)
         eigs_guess = np.zeros((config.spindims, config.lmax), dtype=dtype)
 
-        start_time = time.time()
-
         # A new Hamiltonian has to be re-constructed for every value of l and each spin
         # channel if spin-polarized
         for l in range(config.lmax):
@@ -450,8 +447,6 @@ class Solver:
 
                     # dummy variable for the null eigenfucntions
                     eigfuncs_null = eigfuncs
-
-        end_time = time.time()
 
         if solve_type == "full":
             return eigfuncs, eigvals

--- a/atoMEC/numerov.py
+++ b/atoMEC/numerov.py
@@ -214,17 +214,19 @@ class Solver:
         # solve in serial or parallel - serial mostly useful for debugging
         if config.numcores == 0:
             eigfuncs, eigvals = self.KS_matsolve_serial(
-                T, B, T_sparse, B_sparse, v, xgrid, bc, solve_type, eigs_min_guess
+                T_sparse, B_sparse, v, xgrid, bc, solve_type, eigs_min_guess
             )
 
         else:
             eigfuncs, eigvals = self.KS_matsolve_parallel(
-                T, B, v, xgrid, bc, solve_type, eigs_min_guess
+                T_sparse, B_sparse, v, xgrid, bc, solve_type, eigs_min_guess
             )
 
         return eigfuncs, eigvals
 
-    def KS_matsolve_parallel(self, T, B, v, xgrid, bc, solve_type, eigs_min_guess):
+    def KS_matsolve_parallel(
+        self, T_sparse, B_sparse, v, xgrid, bc, solve_type, eigs_min_guess
+    ):
         """
         Solve the KS matrix diagonalization by parallelizing over config.numcores.
 
@@ -312,16 +314,16 @@ class Solver:
 
         # dump and load the large numpy arrays from file
         data_filename_memmap = os.path.join(joblib_folder, "data_memmap")
-        dump((T, B, v_flat), data_filename_memmap)
-        T, B, v_flat = load(data_filename_memmap, mmap_mode="r")
+        dump((T_sparse, B_sparse, v_flat), data_filename_memmap)
+        T_sparse, B_sparse, v_flat = load(data_filename_memmap, mmap_mode="r")
 
         # set up the parallel job
         with Parallel(n_jobs=config.numcores) as parallel:
             X = parallel(
                 delayed(self.diag_H)(
                     q,
-                    T,
-                    B,
+                    T_sparse,
+                    B_sparse,
                     v_flat,
                     xgrid,
                     config.nmax,
@@ -364,7 +366,7 @@ class Solver:
             return eigfuncs_null, eigs_guess
 
     def KS_matsolve_serial(
-        self, T, B, T_sparse, B_sparse, v, xgrid, bc, solve_type, eigs_min_guess
+        self, T_sparse, B_sparse, v, xgrid, bc, solve_type, eigs_min_guess
     ):
         """
         Solve the KS equations via matrix diagonalization in serial.
@@ -399,8 +401,6 @@ class Solver:
             dtype = self.fp
         # compute the number of grid points
         N = np.size(xgrid)
-        # initialize empty potential matrix
-        V_mat = np.zeros((N, N), dtype=dtype)
 
         # initialize the eigenfunctions and their eigenvalues
         eigfuncs = np.zeros((config.spindims, config.lmax, config.nmax, N), dtype=dtype)
@@ -417,24 +417,18 @@ class Solver:
                     v_corr = 0.5 * (l + 0.5) ** 2 * np.exp(-2 * xgrid)
                 else:
                     v_corr = 3 / (32 * xgrid**4) + l * (l + 1) / (2 * xgrid**4)
-                np.fill_diagonal(V_mat, v[i] + v_corr)
                 V_mat_sparse = diags([v[i] + v_corr], offsets=[0], dtype=dtype)
 
                 # construct Hamiltonians
-                H = T + B @ V_mat
                 H_sparse = T_sparse + B_sparse @ V_mat_sparse
 
                 # if dirichlet solve on (N-1) x (N-1) grid
                 if bc == "dirichlet":
-                    H_s = H[: N - 1, : N - 1]
                     H_sparse_s = self.mat_convert_dirichlet(H_sparse)
-                    B_s = B[: N - 1, : N - 1]
                     B_sparse_s = self.mat_convert_dirichlet(B_sparse)
                 # if neumann don't change anything
                 elif bc == "neumann":
-                    H_s = H
                     H_sparse_s = H_sparse
-                    B_s = B
                     B_sparse_s = B_sparse
 
                 # we seek the lowest nmax eigenvalues from sparse matrix diagonalization
@@ -443,9 +437,9 @@ class Solver:
                 if solve_type == "full":
                     start_time = time.time()
                     eigs_up, vecs_up = eigs(
-                        H_s,
+                        H_sparse_s,
                         k=config.nmax,
-                        M=B_s,
+                        M=B_sparse_s,
                         which="LM",
                         sigma=eigs_min_guess[i, l],
                         tol=config.conv_params["eigtol"],
@@ -464,7 +458,7 @@ class Solver:
                     else:
                         prefac = 8 * xgrid**2
                     for n in range(config.nmax):
-                        K[:, n] = prefac * (V_mat.diagonal() - eigs_up.real[n])
+                        K[:, n] = prefac * (v[i] + v_corr - eigs_up.real[n])
 
                     eigfuncs[i, l], eigvals[i, l] = self.update_orbs(
                         vecs_up, eigs_up, xgrid, bc, K, self.grid_type
@@ -488,7 +482,7 @@ class Solver:
         else:
             return eigfuncs_null, eigs_guess
 
-    def diag_H(self, p, T, B, v, xgrid, nmax, bc, eigs_guess, solve_type):
+    def diag_H(self, p, T_sparse, B_sparse, v, xgrid, nmax, bc, eigs_guess, solve_type):
         """
         Diagonilize the Hamiltonian for the input potential v[p].
 
@@ -526,33 +520,30 @@ class Solver:
             dtype = self.fp
         # compute the number of grid points
         N = np.size(xgrid)
-        # initialize empty potential matrix
-        V_mat = np.zeros((N, N), dtype=dtype)
 
         # fill potential matrices
-        # np.fill_diagonal(V_mat, v + 0.5 * (l + 0.5) ** 2 * np.exp(-2 * xgrid))
-        np.fill_diagonal(V_mat, v[p])
+        V_mat_sparse = diags([v[p]], offsets=[0], dtype=dtype)
 
         # construct Hamiltonians
-        H = T + B @ V_mat
+        H_sparse = T_sparse + B_sparse @ V_mat_sparse
 
         # if dirichlet solve on (N-1) x (N-1) grid
         if bc == "dirichlet":
-            H_s = H[: N - 1, : N - 1]
-            B_s = B[: N - 1, : N - 1]
+            H_sparse_s = self.mat_convert_dirichlet(H_sparse)
+            B_sparse_s = self.mat_convert_dirichlet(B_sparse)
         # if neumann don't change anything
         elif bc == "neumann":
-            H_s = H
-            B_s = B
+            H_sparse_s = H_sparse
+            B_sparse_s = B_sparse
 
         # we seek the lowest nmax eigenvalues from sparse matrix diagonalization
         # use 'shift-invert mode' to find the eigenvalues nearest in magnitude to
         # the estimated lowest eigenvalue from full diagonalization on coarse grid
         if solve_type == "full":
             evals, evecs = eigs(
-                H_s,
+                H_sparse_s,
                 k=nmax,
-                M=B_s,
+                M=B_sparse_s,
                 which="LM",
                 tol=config.conv_params["eigtol"],
                 sigma=eigs_guess[p],
@@ -568,18 +559,18 @@ class Solver:
             K = np.zeros((N, nmax), dtype=dtype)
             for n in range(nmax):
                 if self.grid_type == "log":
-                    K[:, n] = (
-                        -2 * np.exp(2 * xgrid) * (V_mat.diagonal() - evals.real[n])
-                    )
+                    K[:, n] = -2 * np.exp(2 * xgrid) * (v[p] - evals.real[n])
                 else:
-                    K[:, n] = 8 * xgrid**2 * (V_mat.diagonal() - evals.real[n])
+                    K[:, n] = 8 * xgrid**2 * (v[p] - evals.real[n])
             evecs, evals = self.update_orbs(evecs, evals, xgrid, bc, K, self.grid_type)
 
             return evecs, evals
 
         # estimate the lowest eigenvalues for a given value of l
         elif solve_type == "guess":
-            evals = linalg.eigvals(H, b=B, check_finite=False)
+            evals = linalg.eigvals(
+                H_sparse.todense(), b=B_sparse.todense(), check_finite=False
+            )
 
             # sort the eigenvalues to find the lowest
             idr = np.argsort(evals)

--- a/tests/pressure_test_log.py
+++ b/tests/pressure_test_log.py
@@ -23,7 +23,6 @@ virial_expected_corr = 143.06375646995878
 virial_expected_nocorr = 178.2430500359269
 ideal_expected = 103.0141806222132
 ion_expected = 165.19118614722603
-
 accuracy = 0.1
 
 

--- a/tests/spin_test.py
+++ b/tests/spin_test.py
@@ -7,10 +7,9 @@ import numpy as np
 
 
 # expected values and tolerance
-singlet_expected = -37.89807041319449
-triplet_expected = -37.88174335076866
-
-accuracy = 1e-4
+singlet_expected = -37.89758629854574
+triplet_expected = -37.88133924584101
+accuracy = 1e-3
 
 
 class TestSpin:


### PR DESCRIPTION
We get a phenomenal speed-up in the numerov matrix solver if we explicitly pass `scipy.sparse.diags` matrices to `scipy.sparse.eigs`, rather than NxN matrices with mostly null entries. Presumably the memory requirements are also much reduced.