### PR TITLE
Speed up calculation of Hartree potential

### DIFF
--- a/atoMEC/models.py
+++ b/atoMEC/models.py
@@ -378,7 +378,7 @@ class ISModel:
             pot = staticKS.Potential(rho)
 
             # compute energies
-            energy = staticKS.Energy(orbs, rho)
+            energy = staticKS.Energy(orbs, rho, pot)
             E_free = energy.F_tot
 
             # mix potential
@@ -417,7 +417,7 @@ class ISModel:
 
         # compute final density and energy
         rho = staticKS.Density(orbs)
-        energy = staticKS.Energy(orbs, rho)
+        energy = staticKS.Energy(orbs, rho, pot)
 
         # write final output
         scf_final = writeoutput.SCF().write_final(energy, orbs, rho, conv_vals)

--- a/atoMEC/models.py
+++ b/atoMEC/models.py
@@ -378,7 +378,7 @@ class ISModel:
             pot = staticKS.Potential(rho)
 
             # compute energies
-            energy = staticKS.Energy(orbs, rho, pot)
+            energy = staticKS.Energy(orbs, rho)
             E_free = energy.F_tot
 
             # mix potential
@@ -417,7 +417,7 @@ class ISModel:
 
         # compute final density and energy
         rho = staticKS.Density(orbs)
-        energy = staticKS.Energy(orbs, rho, pot)
+        energy = staticKS.Energy(orbs, rho)
 
         # write final output
         scf_final = writeoutput.SCF().write_final(energy, orbs, rho, conv_vals)

--- a/atoMEC/staticKS.py
+++ b/atoMEC/staticKS.py
@@ -34,7 +34,7 @@ Functions
 import numpy as np
 
 # from numba import jit
-from math import sqrt, pi, exp
+from math import sqrt, pi
 
 # internal modules
 from . import config

--- a/atoMEC/staticKS.py
+++ b/atoMEC/staticKS.py
@@ -939,6 +939,7 @@ class Potential:
         # construct the total (sum over spins) density
         rho = np.sum(density, axis=0)
 
+        # components of total hartree potential
         v_ha_u = np.zeros_like(rho)
         v_ha_l = np.zeros_like(rho)
 
@@ -952,11 +953,13 @@ class Potential:
             int_u = 2 * rho * xgrid**3
             prefac_l = xgrid**-2
 
-        int_o = 0.0
-        for i in range(1, N - 1):
-            v_ha_l[i] = prefac_l[i] * (int_o + 0.5 * dx * (int_l[i - 1] + int_l[i]))
-            int_o += 0.5 * dx * (int_l[i - 1] + int_l[i])
+        # save the lower integral without prefac
+        int_l_no_prefac = 0.0
         for i in range(1, N):
+            v_ha_l[i] = prefac_l[i] * (
+                int_l_no_prefac + 0.5 * dx * (int_l[i - 1] + int_l[i])
+            )
+            int_l_no_prefac += 0.5 * dx * (int_l[i - 1] + int_l[i])
             v_ha_u[N - i - 1] = v_ha_u[N - i] + 0.5 * dx * (
                 int_u[N - i] + int_u[N - i - 1]
             )

--- a/atoMEC/staticKS.py
+++ b/atoMEC/staticKS.py
@@ -32,6 +32,7 @@ Functions
 
 # external packages
 import numpy as np
+from numba import jit
 from math import sqrt, pi, exp
 
 # internal modules
@@ -905,6 +906,7 @@ class Potential:
         return v_en
 
     @staticmethod
+    @jit(nopython=True, nogil=True, cache=True, fastmath=True)
     def calc_v_ha(density, xgrid, grid_type):
         r"""
         Construct the Hartree potential (see notes).

--- a/atoMEC/staticKS.py
+++ b/atoMEC/staticKS.py
@@ -934,33 +934,34 @@ class Potential:
         # initialize v_ha
         v_ha_u = np.zeros_like(xgrid)
         v_ha_l = np.zeros_like(xgrid)
+        N = len(xgrid)
 
         # construct the total (sum over spins) density
         rho = np.sum(density, axis=0)
 
-        # loop over the x-grid
-        # this may be a bottleneck...
-        for i, x0 in enumerate(xgrid):
-            # set up 'upper' and 'lower' parts of the xgrid (x<=x0; x>x0)
-            x_u = xgrid[np.where(x0 < xgrid)]
-            x_l = xgrid[np.where(x0 >= xgrid)]
+        v_ha_u = np.zeros_like(rho)
+        v_ha_l = np.zeros_like(rho)
 
-            # likewise for the density
-            rho_u = rho[np.where(x0 < xgrid)]
-            rho_l = rho[np.where(x0 >= xgrid)]
+        dx = xgrid[1] - xgrid[0]
+        if grid_type == "log":
+            int_l = rho * np.exp(3 * xgrid)
+            int_u = rho * np.exp(2 * xgrid)
+            prefac_l = np.exp(-xgrid)
+        else:
+            int_l = 2 * rho * xgrid**5
+            int_u = 2 * rho * xgrid**3
+            prefac_l = xgrid**-2
 
-            # now compute the hartree potential
-            if grid_type == "log":
-                v_ha_l[i] = exp(-x0) * np.trapz(rho_l * np.exp(3.0 * x_l), x_l)
-                v_ha_u[i] = np.trapz(rho_u * np.exp(2 * x_u), x_u)
-            else:
-                v_ha_l[i] = (1 / x0**2) * np.trapz(rho_l * 2 * x_l**5, x_l)
-                v_ha_u[i] = np.trapz(rho_u * 2 * x_u**3, x_u)
+        int_o = 0.0
+        for i in range(1, N - 1):
+            v_ha_l[i] = prefac_l[i] * (int_o + 0.5 * dx * (int_l[i - 1] + int_l[i]))
+            int_o += 0.5 * dx * (int_l[i - 1] + int_l[i])
+        for i in range(1, N):
+            v_ha_u[N - i - 1] = v_ha_u[N - i] + 0.5 * dx * (
+                int_u[N - i] + int_u[N - i - 1]
+            )
 
-        # total hartree potential is sum over integrals
-        # have to shift upper integral by one index to match
-        v_ha_u[1:] = v_ha_u[:-1]
-        v_ha = 4.0 * pi * (v_ha_l + v_ha_u)
+        v_ha = 4.0 * pi * (v_ha_u + v_ha_l)
 
         return v_ha
 
@@ -1041,9 +1042,7 @@ class Energy:
     def E_ha(self):
         """float: The Hartree energy."""
         if self._E_ha == 0.0:
-            self._E_ha = self.calc_E_ha(
-                self._dens, self._v_ha, self._xgrid, self.grid_type
-            )
+            self._E_ha = self.calc_E_ha(self._dens, self._xgrid, self.grid_type)
         return self._E_ha
 
     @property
@@ -1428,7 +1427,7 @@ class Energy:
         return E_en
 
     @staticmethod
-    def calc_E_ha(density, v_ha, xgrid, grid_type):
+    def calc_E_ha(density, xgrid, grid_type):
         r"""
         Compute the Hartree energy.
 
@@ -1456,7 +1455,7 @@ class Energy:
         dens_tot = np.sum(density, axis=0)
 
         # compute the integral
-        # v_ha_alt = Potential.calc_v_ha(density, xgrid, grid_type)
+        v_ha = Potential.calc_v_ha(density, xgrid, grid_type)
         E_ha = 0.5 * mathtools.int_sphere(dens_tot * v_ha, xgrid, grid_type)
 
         return E_ha
@@ -1576,9 +1575,7 @@ class EnergyAlt:
     def E_ha(self):
         """float: The Hartree energy."""
         if self._E_ha == 0.0:
-            self._E_ha = Energy.calc_E_ha(
-                self._dens, self._pot.v_ha, self._xgrid, self.grid_type
-            )
+            self._E_ha = Energy.calc_E_ha(self._dens, self._xgrid, self.grid_type)
         return self._E_ha
 
     @property
@@ -1625,7 +1622,7 @@ class EnergyAlt:
 
         """
         # first compute the hartree contribution, which is twice the hartree energy
-        E_v_ha = 2.0 * Energy.calc_E_ha(dens, pot.v_ha, xgrid, grid_type)
+        E_v_ha = 2.0 * Energy.calc_E_ha(dens, xgrid, grid_type)
 
         # now compute the xc contribution (over each spin channel)
         E_v_xc = 0.0

--- a/atoMEC/staticKS.py
+++ b/atoMEC/staticKS.py
@@ -32,7 +32,8 @@ Functions
 
 # external packages
 import numpy as np
-from numba import jit
+
+# from numba import jit
 from math import sqrt, pi, exp
 
 # internal modules
@@ -906,7 +907,6 @@ class Potential:
         return v_en
 
     @staticmethod
-    @jit(nopython=True, nogil=True, cache=True, fastmath=True)
     def calc_v_ha(density, xgrid, grid_type):
         r"""
         Construct the Hartree potential (see notes).
@@ -968,10 +968,11 @@ class Potential:
 class Energy:
     r"""Class holding information about the KS total energy and relevant routines."""
 
-    def __init__(self, orbs, dens):
+    def __init__(self, orbs, dens, pot):
         # inputs
         self._orbs = orbs
         self._dens = dens.total
+        self._v_ha = pot.v_ha
         self._xgrid = dens._xgrid
 
         # initialize attributes
@@ -1040,7 +1041,9 @@ class Energy:
     def E_ha(self):
         """float: The Hartree energy."""
         if self._E_ha == 0.0:
-            self._E_ha = self.calc_E_ha(self._dens, self._xgrid, self.grid_type)
+            self._E_ha = self.calc_E_ha(
+                self._dens, self._v_ha, self._xgrid, self.grid_type
+            )
         return self._E_ha
 
     @property
@@ -1425,7 +1428,7 @@ class Energy:
         return E_en
 
     @staticmethod
-    def calc_E_ha(density, xgrid, grid_type):
+    def calc_E_ha(density, v_ha, xgrid, grid_type):
         r"""
         Compute the Hartree energy.
 
@@ -1453,7 +1456,7 @@ class Energy:
         dens_tot = np.sum(density, axis=0)
 
         # compute the integral
-        v_ha = Potential.calc_v_ha(density, xgrid, grid_type)
+        # v_ha_alt = Potential.calc_v_ha(density, xgrid, grid_type)
         E_ha = 0.5 * mathtools.int_sphere(dens_tot * v_ha, xgrid, grid_type)
 
         return E_ha
@@ -1573,7 +1576,9 @@ class EnergyAlt:
     def E_ha(self):
         """float: The Hartree energy."""
         if self._E_ha == 0.0:
-            self._E_ha = Energy.calc_E_ha(self._dens, self._xgrid, self.grid_type)
+            self._E_ha = Energy.calc_E_ha(
+                self._dens, self._pot.v_ha, self._xgrid, self.grid_type
+            )
         return self._E_ha
 
     @property
@@ -1620,7 +1625,7 @@ class EnergyAlt:
 
         """
         # first compute the hartree contribution, which is twice the hartree energy
-        E_v_ha = 2.0 * Energy.calc_E_ha(dens, xgrid, grid_type)
+        E_v_ha = 2.0 * Energy.calc_E_ha(dens, pot.v_ha, xgrid, grid_type)
 
         # now compute the xc contribution (over each spin channel)
         E_v_xc = 0.0

--- a/atoMEC/staticKS.py
+++ b/atoMEC/staticKS.py
@@ -972,11 +972,10 @@ class Potential:
 class Energy:
     r"""Class holding information about the KS total energy and relevant routines."""
 
-    def __init__(self, orbs, dens, pot):
+    def __init__(self, orbs, dens):
         # inputs
         self._orbs = orbs
         self._dens = dens.total
-        self._v_ha = pot.v_ha
         self._xgrid = dens._xgrid
 
         # initialize attributes


### PR DESCRIPTION
Significant speed-up for Hartree potential achieved by replacing expensive calls to np.where and np.trapz