### PR TITLE
Fix issue with eigenvalue guess

### DIFF
--- a/atoMEC/numerov.py
+++ b/atoMEC/numerov.py
@@ -436,8 +436,9 @@ class Solver:
 
                 elif solve_type == "guess":
                     # estimate the lowest eigenvalues for a given value of l
+                    invB = linalg.inv(B_sparse.todense())
                     eigs_up = linalg.eigvals(
-                        H_sparse.todense(), b=B_sparse.todense(), check_finite=False
+                        invB * H_sparse.todense(), check_finite=False
                     )
 
                     # sort the eigenvalues to find the lowest
@@ -538,9 +539,8 @@ class Solver:
 
         # estimate the lowest eigenvalues for a given value of l
         elif solve_type == "guess":
-            evals = linalg.eigvals(
-                H_sparse.todense(), b=B_sparse.todense(), check_finite=False
-            )
+            invB = linalg.inv(B_sparse.todense())
+            evals = linalg.eigvals(invB * H_sparse.todense(), check_finite=False)
 
             # sort the eigenvalues to find the lowest
             idr = np.argsort(evals)

--- a/atoMEC/numerov.py
+++ b/atoMEC/numerov.py
@@ -436,10 +436,13 @@ class Solver:
 
                 elif solve_type == "guess":
                     # estimate the lowest eigenvalues for a given value of l
-                    invB = linalg.inv(B_sparse.todense())
+                    B_dense = B_sparse.todense()
+                    invB = linalg.inv(B_dense)
                     eigs_up = linalg.eigvals(
                         invB * H_sparse.todense(), check_finite=False
                     )
+                    if not np.all(np.isclose(invB * B_dense, np.eye(len(xgrid)))):
+                        print("Warning: B matrix in eigs_guess is ill-conditioned")
 
                     # sort the eigenvalues to find the lowest
                     idr = np.argsort(eigs_up)
@@ -539,8 +542,11 @@ class Solver:
 
         # estimate the lowest eigenvalues for a given value of l
         elif solve_type == "guess":
-            invB = linalg.inv(B_sparse.todense())
+            B_dense = B_sparse.todense()
+            invB = linalg.inv(B_dense)
             evals = linalg.eigvals(invB * H_sparse.todense(), check_finite=False)
+            if not np.all(np.isclose(invB * B_dense, np.eye(len(xgrid)))):
+                print("Warning: B matrix in eigs_guess is ill-conditioned")
 
             # sort the eigenvalues to find the lowest
             idr = np.argsort(evals)


### PR DESCRIPTION
`scipy.linalg.eigvals` seems to have a problem solving the _generalized_ eigenvalue problem A*x = B*lambda*x when B is ill-conditioned (which is typically the case in atoMEC). This causes the guess eigenvalues to have errors. This usually doesn't affect the final results but it can do.

In this PR, we invert B and then solve B^-1*A*x = lambda*x, which seems numerically stable.