### PR TITLE
Remove config.fp option for float precision

### DIFF
--- a/atoMEC/config.py
+++ b/atoMEC/config.py
@@ -32,7 +32,6 @@ band_params = {"nkpts": 50, "de_min": 1e-3}
 force_bound = []
 
 grid_type = "log"
-fp = np.float64
 
 # parallelization
 numcores = 0  # defaults to serial

--- a/atoMEC/config.py
+++ b/atoMEC/config.py
@@ -1,7 +1,5 @@
 """Configuration file to store global parameters."""
 
-import numpy as np
-
 # physical constants
 mp_g = 1.6726219e-24  # mass of proton in grams
 

--- a/atoMEC/convergence.py
+++ b/atoMEC/convergence.py
@@ -32,13 +32,9 @@ class SCF:
 
     def __init__(self, xgrid, grid_type):
         self._xgrid = xgrid
-        self._energy = np.zeros((2), dtype=config.fp)
-        self._potential = np.zeros(
-            (2, config.spindims, config.grid_params["ngrid"]), dtype=config.fp
-        )
-        self._density = np.zeros(
-            (2, config.spindims, config.grid_params["ngrid"]), dtype=config.fp
-        )
+        self._energy = np.zeros((2))
+        self._potential = np.zeros((2, config.spindims, config.grid_params["ngrid"]))
+        self._density = np.zeros((2, config.spindims, config.grid_params["ngrid"]))
         self.grid_type = grid_type
 
     def check_conv(self, E_free, pot, dens, iscf):

--- a/atoMEC/numerov.py
+++ b/atoMEC/numerov.py
@@ -17,7 +17,6 @@ import os
 import shutil
 import string
 import random
-import warnings
 
 # external libs
 import numpy as np

--- a/atoMEC/postprocess/conductivity.py
+++ b/atoMEC/postprocess/conductivity.py
@@ -25,7 +25,7 @@ from scipy.special import lpmv
 from scipy.integrate import quad
 
 # internal modules
-from atoMEC import mathtools, config
+from atoMEC import mathtools
 
 
 class KuboGreenwood:
@@ -320,7 +320,7 @@ Please run again with spin-unpolarized input."
 
         # initialize sum_mom and various indices
         nbands, nspin, lmax, nmax = np.shape(self._eigvals)
-        sum_mom = np.zeros((nbands), dtype=config.fp)
+        sum_mom = np.zeros((nbands))
 
         # compute the sum rule
         for k in range(nbands):
@@ -517,10 +517,8 @@ Please run again with spin-unpolarized input."
         omega_arr = np.linspace(1e-5, np.sqrt(omega_max), n_freq) ** 2
 
         # set up lorentzian: requires dummy array to get right shape
-        sig_omega = np.zeros((np.size(omega_arr), 2), dtype=config.fp)
-        omega_dummy_mat = np.ones(
-            (nbands, lmax, nmax, lmax, nmax, n_freq), dtype=config.fp
-        )
+        sig_omega = np.zeros((np.size(omega_arr), 2))
+        omega_dummy_mat = np.ones((nbands, lmax, nmax, lmax, nmax, n_freq))
         eig_diff_omega_mat = np.einsum(
             "nijkl,nijklm->nijklm", eig_diff_mat, omega_dummy_mat
         )
@@ -700,7 +698,7 @@ class SphHamInts:
         P2 and P4 functions, ands the :func:`P2_func`, :func:`P4_func` and
         :func:`P_int` functions.
         """
-        P_mat = np.zeros((lmax, lmax, 2 * lmax + 1), dtype=config.fp)
+        P_mat = np.zeros((lmax, lmax, 2 * lmax + 1))
 
         for l1 in range(lmax):
             for l2 in range(lmax):

--- a/atoMEC/postprocess/localization.py
+++ b/atoMEC/postprocess/localization.py
@@ -19,7 +19,7 @@ from scipy.signal import argrelmin
 import numpy as np
 
 # internal modules
-from atoMEC import staticKS, mathtools, check_inputs, config
+from atoMEC import staticKS, mathtools, check_inputs
 
 
 class ELFTools:

--- a/atoMEC/postprocess/localization.py
+++ b/atoMEC/postprocess/localization.py
@@ -65,8 +65,8 @@ class ELFTools:
         spindims = np.shape(self._eigfuncs)[1]
         ngrid = np.shape(self._eigfuncs)[4]
 
-        self._ELF = np.zeros((spindims, ngrid), dtype=config.fp)
-        self._epdc = np.zeros((spindims, ngrid), dtype=config.fp)
+        self._ELF = np.zeros((spindims, ngrid))
+        self._epdc = np.zeros((spindims, ngrid))
         self._N_shell = None
 
     @property
@@ -410,7 +410,7 @@ def calc_IPR_mat(eigfuncs, xgrid, grid_type=None):
     lmax = np.shape(eigfuncs)[2]
     nmax = np.shape(eigfuncs)[3]
 
-    IPR_mat = np.zeros((nkpts, spindims, lmax, nmax), dtype=config.fp)
+    IPR_mat = np.zeros((nkpts, spindims, lmax, nmax))
 
     # compute the IPR matrix
     # FIXME: add spherical harmonic term

--- a/atoMEC/staticKS.py
+++ b/atoMEC/staticKS.py
@@ -115,11 +115,9 @@ class Orbitals:
                 config.nmax,
                 config.grid_params["ngrid"],
             ),
-            dtype=config.fp,
         )
         self._eigvals = np.zeros(
             (config.band_params["nkpts"], config.spindims, config.lmax, config.nmax),
-            dtype=config.fp,
         )
         self._occnums = np.zeros_like(self._eigvals)
         self._occnums_w = np.zeros_like(self._eigvals)
@@ -127,13 +125,12 @@ class Orbitals:
         self._DOS = np.ones_like(self._eigvals)
         self._eigs_min_guess = np.zeros(
             (config.band_params["nkpts"], config.spindims, config.lmax),
-            dtype=np.float64,
         )
         self._eigvals_min = np.zeros(
-            (config.band_params["nkpts"], config.spindims, config.lmax), dtype=config.fp
+            (config.band_params["nkpts"], config.spindims, config.lmax)
         )
         self._eigvals_max = np.zeros(
-            (config.band_params["nkpts"], config.spindims, config.lmax), dtype=config.fp
+            (config.band_params["nkpts"], config.spindims, config.lmax)
         )
         self._kpt_int_weight = np.ones_like(self._eigvals)
         self._occ_weight = np.zeros_like(self._eigvals)
@@ -242,7 +239,7 @@ class Orbitals:
         None
         """
         # ensure the potential has the correct dimensions
-        v = np.zeros((config.spindims, config.grid_params["ngrid"]), dtype=config.fp)
+        v = np.zeros((config.spindims, config.grid_params["ngrid"]))
 
         # set v to equal the input potential
         v[:] = potential
@@ -294,7 +291,7 @@ class Orbitals:
 
         # guess the chemical potential if initializing
         if init:
-            config.mu = np.zeros((config.spindims), dtype=config.fp)
+            config.mu = np.zeros((config.spindims))
         return
 
     # @writeoutput.timing
@@ -329,7 +326,6 @@ class Orbitals:
             self.eigvals_min,
             self.eigvals_max,
             config.band_params["nkpts"],
-            dtype=config.fp,
         )
 
         # propagate the numerov equation
@@ -558,9 +554,9 @@ class Orbitals:
         nspin, lmax, nmax = np.shape(eigs_max)
 
         e_arr_dummy = Orbitals.make_e_arr(eigs_min, eigs_max, 0)
-        e_arr = np.zeros((len(e_arr_dummy), nspin), dtype=config.fp)
-        dos_knl = np.zeros((len(e_arr_dummy), nspin, lmax, nmax), dtype=config.fp)
-        fd_dist = np.zeros((len(e_arr_dummy), nspin), dtype=config.fp)
+        e_arr = np.zeros((len(e_arr_dummy), nspin))
+        dos_knl = np.zeros((len(e_arr_dummy), nspin, lmax, nmax))
+        fd_dist = np.zeros((len(e_arr_dummy), nspin))
 
         for sp in range(nspin):
             # make the total energy array
@@ -629,7 +625,7 @@ class Orbitals:
         )
 
         # make the energy array
-        e_tot_arr = np.array([], dtype=config.fp)
+        e_tot_arr = np.array([])
         for p in range(len(eigs_min) - 1):
             # ignore energies below the minimum for bands
             if eigs_min[p] < e_min:
@@ -693,20 +689,14 @@ class Density:
 
     def __init__(self, orbs):
         self._xgrid = orbs._xgrid
-        self._total = np.zeros(
-            (config.spindims, config.grid_params["ngrid"]), dtype=config.fp
-        )
+        self._total = np.zeros((config.spindims, config.grid_params["ngrid"]))
         self._bound = {
-            "rho": np.zeros(
-                (config.spindims, config.grid_params["ngrid"]), dtype=config.fp
-            ),
-            "N": np.zeros((config.spindims), dtype=config.fp),
+            "rho": np.zeros((config.spindims, config.grid_params["ngrid"])),
+            "N": np.zeros((config.spindims)),
         }
         self._unbound = {
-            "rho": np.zeros(
-                (config.spindims, config.grid_params["ngrid"]), dtype=config.fp
-            ),
-            "N": np.zeros((config.spindims), dtype=config.fp),
+            "rho": np.zeros((config.spindims, config.grid_params["ngrid"])),
+            "N": np.zeros((config.spindims)),
         }
 
         self._MIS = 0.0
@@ -814,10 +804,8 @@ class Density:
             contains the keys `rho` and `N` denoting the unbound density
             and number of unbound electrons respectively
         """
-        rho_unbound = np.zeros(
-            (config.spindims, config.grid_params["ngrid"]), dtype=config.fp
-        )
-        N_unbound = np.zeros((config.spindims), dtype=config.fp)
+        rho_unbound = np.zeros((config.spindims, config.grid_params["ngrid"]))
+        N_unbound = np.zeros((config.spindims))
 
         # so far only the ideal approximation is implemented
         if config.unbound == "ideal":
@@ -840,8 +828,8 @@ class Potential:
 
     def __init__(self, density):
         self._v_s = np.zeros_like(density.total)
-        self._v_en = np.zeros((config.grid_params["ngrid"]), dtype=config.fp)
-        self._v_ha = np.zeros((config.grid_params["ngrid"]), dtype=config.fp)
+        self._v_en = np.zeros((config.grid_params["ngrid"]))
+        self._v_ha = np.zeros((config.grid_params["ngrid"]))
         self._v_xc = {
             "x": np.zeros_like(density.total),
             "c": np.zeros_like(density.total),

--- a/atoMEC/xc.py
+++ b/atoMEC/xc.py
@@ -265,7 +265,7 @@ def calc_xc(density, xgrid, xcfunc, xctype):
 
     # determine the dimensions of the xc_arr based on xctype
     if xctype == "e_xc":
-        xc_arr = np.zeros((config.grid_params["ngrid"]), dtype=config.fp)
+        xc_arr = np.zeros((config.grid_params["ngrid"]))
     elif xctype == "v_xc":
         xc_arr = np.zeros_like(density)
 
@@ -290,9 +290,7 @@ def calc_xc(density, xgrid, xcfunc, xctype):
         if xcfunc._family == 1:
             # lda just needs density as input
             # messy transformation for libxc - why isn't tranpose working??
-            rho_libxc = np.zeros(
-                (config.grid_params["ngrid"], config.spindims), dtype=config.fp
-            )
+            rho_libxc = np.zeros((config.grid_params["ngrid"], config.spindims))
             for i in range(config.spindims):
                 rho_libxc[:, i] = density[i, :]
             inp = {"rho": rho_libxc}
@@ -305,26 +303,20 @@ def calc_xc(density, xgrid, xcfunc, xctype):
                 xc_arr = out["vrho"].transpose()
         # gga
         if xcfunc._family == 2:
-            rho_libxc = np.zeros(
-                (config.grid_params["ngrid"], config.spindims), dtype=config.fp
-            )
+            rho_libxc = np.zeros((config.grid_params["ngrid"], config.spindims))
 
             for i in range(config.spindims):
                 rho_libxc[:, i] = density[i, :]
             # preparing the sigma array needed for libxc gga calculation
             if config.spindims == 2:
-                sigma_libxc = np.zeros(
-                    (config.grid_params["ngrid"], 3), dtype=config.fp
-                )
+                sigma_libxc = np.zeros((config.grid_params["ngrid"], 3))
                 grad_0 = mathtools.grad_func(density[0, :], xgrid, config.grid_type)
                 grad_1 = mathtools.grad_func(density[1, :], xgrid, config.grid_type)
                 sigma_libxc[:, 0] = grad_0**2
                 sigma_libxc[:, 1] = grad_0 * grad_1
                 sigma_libxc[:, 2] = grad_1**2
             else:
-                sigma_libxc = np.zeros(
-                    (config.grid_params["ngrid"], 1), dtype=config.fp
-                )
+                sigma_libxc = np.zeros((config.grid_params["ngrid"], 1))
                 grad = mathtools.grad_func(density[0, :], xgrid, config.grid_type)
                 sigma_libxc[:, 0] = grad**2
 
@@ -342,9 +334,7 @@ def calc_xc(density, xgrid, xcfunc, xctype):
                         out, grad_0, grad_1, xgrid, 2
                     )
                 else:
-                    xc_arr = np.zeros(
-                        (config.grid_params["ngrid"], config.spindims), dtype=config.fp
-                    )
+                    xc_arr = np.zeros((config.grid_params["ngrid"], config.spindims))
                     # Using the chain rule to obtain the gga xc pot
                     # from the libxc calculation:
                     for i in range(config.spindims):
@@ -424,7 +414,6 @@ def gga_pot_chainrule(libxc_output, grad_0, grad_1, xgrid, spindims):
                 (1 / r2) * mathtools.grad_func(r2 * term1, xgrid, config.grid_type),
                 (1 / r2) * mathtools.grad_func(r2 * term2, xgrid, config.grid_type),
             ),
-            dtype=config.fp,
         )
     else:
         gga_addition2 = (


### PR DESCRIPTION
This feature should not have been added to the `dev` branch, after all things considered. It is too unstable and, with the improvements to the code, no longer particularly useful.

This PR removes the option for the user to use float32 precision.