### PR TITLE
Use a better set of defaults

### DIFF
--- a/atoMEC/config.py
+++ b/atoMEC/config.py
@@ -7,16 +7,16 @@ mp_g = 1.6726219e-24  # mass of proton in grams
 spinpol = False  # spin-polarized functional
 xfunc_id = "lda_x"  # exchange functional (libxc ref)
 cfunc_id = "lda_c_pw"  # correlation functional (libxc ref)
-bc = "dirichlet"  # boundary condition
-unbound = "ideal"  # treatment for unbound electrons
+bc = "bands"  # boundary condition
+unbound = "quantum"  # treatment for unbound electrons
 v_shift = True  # whether to shift the KS potential vertically
 
 # numerical grid for static calculations
-grid_params = {"ngrid": 1000, "x0": -12, "ngrid_coarse": 300, "s0": 1e-3}
+grid_params = {"ngrid": 500, "x0": -12, "ngrid_coarse": 300, "s0": 1e-3}
 # convergence parameters for static calculations
 conv_params = {
-    "econv": 1.0e-5,
-    "nconv": 1.0e-4,
+    "econv": 1.0e-6,
+    "nconv": 1.0e-5,
     "vconv": 1.0e-4,
     "eigtol": 1.0e-4,
     "bandtol": 1.0e-3,
@@ -24,12 +24,12 @@ conv_params = {
 # scf parameters
 scf_params = {"maxscf": 50, "mixfrac": 0.3}
 # band parameters for massacrier band model
-band_params = {"nkpts": 50, "de_min": 1e-3}
+band_params = {"nkpts": 30, "de_min": 1e-3}
 
 # forced bound energy levels (default none)
 force_bound = []
 
-grid_type = "log"
+grid_type = "sqrt"
 
 # parallelization
 numcores = 0  # defaults to serial

--- a/tests/boundary_conditions_test.py
+++ b/tests/boundary_conditions_test.py
@@ -81,6 +81,7 @@ class TestBcs:
 
 if __name__ == "__main__":
     config.numcores = -1
+    config.fp = np.float32
     dirichlet = TestBcs._run("dirichlet")
     neumann = TestBcs._run("neumann")
     bands = TestBcs._run("bands")

--- a/tests/functionals_test.py
+++ b/tests/functionals_test.py
@@ -12,11 +12,11 @@ import numpy as np
 
 
 # expected values and tolerance
-lda_expected = -158.66453567079228
-gdsmfb_expected = -158.6079090856573
-no_xc_expected = -144.49795725080637
-no_hxc_expected = -249.50772961499766
-gga_expected = -159.37528906276566
+lda_expected = -161.13694055882937
+gdsmfb_expected = -161.07726791735197
+no_xc_expected = -147.69699056522276
+no_hxc_expected = -249.7299062816172
+gga_expected = -161.79172099868805
 accuracy = 1e-3
 
 
@@ -91,6 +91,7 @@ class TestFuncs:
             6,
             scf_params={"maxscf": 5, "mixfrac": 0.3},
             grid_params={"ngrid": 1000},
+            band_params={"nkpts": 30},
         )
 
         # extract the total free energy

--- a/tests/localization_test.py
+++ b/tests/localization_test.py
@@ -91,7 +91,9 @@ class TestLocalization:
 
         # set up the atom and model
         Al_at = Atom("Al", 0.01, radius=5.0, units_temp="eV")
-        model = models.ISModel(Al_at, unbound="quantum", spinpol=spinpol)
+        model = models.ISModel(
+            Al_at, unbound="quantum", bc="dirichlet", spinpol=spinpol
+        )
 
         # run the SCF calculation
         output = model.CalcEnergy(
@@ -136,6 +138,7 @@ class TestLocalization:
             unbound=input_SCF["model"].unbound,
             spinpol=input_SCF["model"].spinpol,
             write_info=False,
+            bc="dirichlet",
         )
 
         ELF = localization.ELFTools(
@@ -177,6 +180,7 @@ class TestLocalization:
             unbound=input_SCF["model"].unbound,
             spinpol=input_SCF["model"].spinpol,
             write_info=False,
+            bc="dirichlet",
         )
 
         ELF = localization.ELFTools(

--- a/tests/pressure_test_log.py
+++ b/tests/pressure_test_log.py
@@ -113,6 +113,7 @@ class TestPressure:
             grid_params={"ngrid": 1000},
             band_params={"nkpts": 50},
             verbosity=1,
+            grid_type="log",
         )
 
         output_dict = {"Atom": Li_at, "model": model, "SCF_out": output}

--- a/tests/unbound_test.py
+++ b/tests/unbound_test.py
@@ -42,7 +42,7 @@ class TestUnbound:
             units_temp="eV",
             units_radius="angstrom",
         )
-        model = models.ISModel(Be_at, unbound="ideal")
+        model = models.ISModel(Be_at, unbound="ideal", bc="dirichlet")
 
         # run the SCF calculation
         output = model.CalcEnergy(


### PR DESCRIPTION
As raised in #186, the current defaults in atoMEC were those implemented at the very start and are now known to be quite poor. In fact they should be used under almost no circumstances. 

The convergence defaults are based on analysis of convergence parameters from >2000 calculations for a range of temperatures and densities.

Strictly, changing the defaults should be part of a new major release. However, since we don't change the API in a fundamental way, these changes will be part of the next minor release.