### PR TITLE
Allow convergence after two SCF cycles

### DIFF
--- a/atoMEC/convergence.py
+++ b/atoMEC/convergence.py
@@ -104,7 +104,7 @@ class SCF:
         conv_pot = False
         conv_vals["complete"] = False
 
-        if iscf > 3:
+        if iscf > 1:
             if conv_vals["dE"] < config.conv_params["econv"]:
                 conv_energy = True
             if np.all(conv_vals["drho"] < config.conv_params["nconv"]):

--- a/tests/pressure_log_test.py
+++ b/tests/pressure_log_test.py
@@ -110,7 +110,7 @@ class TestPressure:
         output = model.CalcEnergy(
             3,
             3,
-            scf_params={"maxscf": 5},
+            scf_params={"maxscf": 5, "mixfrac": 0.3},
             grid_params={"ngrid": 1000},
             band_params={"nkpts": 50},
             verbosity=1,

--- a/tests/pressure_sqrt_test.py
+++ b/tests/pressure_sqrt_test.py
@@ -102,7 +102,7 @@ class TestPressure:
         output = model.CalcEnergy(
             6,
             8,
-            scf_params={"maxscf": 5},
+            scf_params={"maxscf": 5, "mixfrac": 0.3},
             grid_params={"ngrid": 1000},
             band_params={"nkpts": 50},
             verbosity=1,

--- a/tests/unbound_test.py
+++ b/tests/unbound_test.py
@@ -48,7 +48,7 @@ class TestUnbound:
         output = model.CalcEnergy(
             3,
             3,
-            scf_params={"maxscf": 3},
+            scf_params={"maxscf": 3, "mixfrac": 0.3},
             grid_params={"ngrid": 1000},
             force_bound=[[0, 0, 0]],
         )


### PR DESCRIPTION
The current convergence criteria are a bit too strict, since often calculations have converged after 2 scf runs. This changes the minimum scf cycles from 4 to 2.