### PR TITLE
Make mixfrac explicit in tests

### DIFF
--- a/tests/pressure_log_test.py
+++ b/tests/pressure_log_test.py
@@ -110,7 +110,7 @@ class TestPressure:
         output = model.CalcEnergy(
             3,
             3,
-            scf_params={"maxscf": 5},
+            scf_params={"maxscf": 5, "mixfrac": 0.3},
             grid_params={"ngrid": 1000},
             band_params={"nkpts": 50},
             verbosity=1,

--- a/tests/pressure_sqrt_test.py
+++ b/tests/pressure_sqrt_test.py
@@ -102,7 +102,7 @@ class TestPressure:
         output = model.CalcEnergy(
             6,
             8,
-            scf_params={"maxscf": 5},
+            scf_params={"maxscf": 5, "mixfrac": 0.3},
             grid_params={"ngrid": 1000},
             band_params={"nkpts": 50},
             verbosity=1,

--- a/tests/unbound_test.py
+++ b/tests/unbound_test.py
@@ -48,7 +48,7 @@ class TestUnbound:
         output = model.CalcEnergy(
             3,
             3,
-            scf_params={"maxscf": 3},
+            scf_params={"maxscf": 3, "mixfrac": 0.3},
             grid_params={"ngrid": 1000},
             force_bound=[[0, 0, 0]],
         )


### PR DESCRIPTION
Tests were sometimes failing unexpectly, this is because the `mixfrac` parameter has to be explicitly reset
