### PR TITLE
Allow convergence after 2 scf cycles

### DIFF
--- a/atoMEC/convergence.py
+++ b/atoMEC/convergence.py
@@ -104,7 +104,7 @@ class SCF:
         conv_pot = False
         conv_vals["complete"] = False
 
-        if iscf > 3:
+        if iscf > 1:
             if conv_vals["dE"] < config.conv_params["econv"]:
                 conv_energy = True
             if np.all(conv_vals["drho"] < config.conv_params["nconv"]):


### PR DESCRIPTION
Previously at least 4 SCF cycles were required until convergence was considered. This is too strict so we reduce it to two.