### PR TITLE
Fix stated temperature range of atoMEC

### DIFF
--- a/atoMEC/check_inputs.py
+++ b/atoMEC/check_inputs.py
@@ -1176,7 +1176,7 @@ class InputWarning:
             "Warning: this input temperature is very "
             + err
             + ". Proceeding anyway, but results may not be accurate. \n"
-            + "Normal temperature range for atoMEC is 0.01 -- 100 eV \n"
+            + "Normal temperature range for atoMEC is 0.1 -- 1000 eV \n"
         )
         return warning
 


### PR DESCRIPTION
Relates to issue #147 . The temperature range stated in the warning now matches that which triggers the warning