### PR TITLE
Update atoMEC logo to use url for PyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![image](./docs/source/img/logos/atoMEC_horizontal2.png)
+![image](https://github.com/atomec-project/atoMEC/blob/develop/docs/source/img/logos/atoMEC_horizontal2.png)
 
 # atoMEC: Average-Atom Code for Matter under Extreme Conditions
 


### PR DESCRIPTION
An attempt to fix issue #116, by changing the image location from a path to a url