### PR TITLE
Enforce log grid

### DIFF
--- a/atoMEC/postprocess/conductivity.py
+++ b/atoMEC/postprocess/conductivity.py
@@ -44,6 +44,12 @@ class KuboGreenwood:
                 "Kubo-Greenwood is not yet set-up for spin-polarized calculations. \
 Please run again with spin-unpolarized input."
             )
+
+        if orbitals.grid_type != "log":
+            sys.exit(
+                "Sqrt grid is not yet supported for Kubo-Greenwood calculations."
+                "Please switch to log grid."
+            )
         if nmax == 0:
             self._nmax = nmax_default
         else:

--- a/atoMEC/staticKS.py
+++ b/atoMEC/staticKS.py
@@ -1669,9 +1669,16 @@ class EnergyAlt:
 class GramSchmidt:
     """Class holding Gram-Schmidt orthoganalization process."""
 
-    def __init__(self, eigfuncs, xgrid):
+    def __init__(self, eigfuncs, xgrid, grid_type):
         self._eigfuncs = eigfuncs
         self._xgrid = xgrid
+
+        # check grid is logarithmic
+        if grid_type != "log":
+            raise check_inputs.InputError.grid_error(
+                "Sqrt grid is not yet supported for Gram-Schmidt procedure."
+                "Please switch to log grid."
+            )
 
     def make_ortho(self):
         """

--- a/tests/gramschmidt_test.py
+++ b/tests/gramschmidt_test.py
@@ -6,7 +6,7 @@ Run an SCF calculation and uses the resulting orbs to calculate overlap
 integrals and perform Gram-Schmidt orthonormalization.
 """
 
-from atoMEC import Atom, models, staticKS
+from atoMEC import Atom, models, staticKS, config
 import pytest
 from pytest_lazyfixture import lazy_fixture
 import numpy as np
@@ -34,6 +34,7 @@ class TestGS:
     )
     def test_overlap(self, input_SCF, case, expected):
         """Run overlap integral after orthonormalizatation."""
+        config.grid_type = "log"
         assert np.isclose(
             self._run_overlap(input_SCF, case),
             expected,
@@ -88,7 +89,7 @@ class TestGS:
 
         """
         xgrid = input_SCF["orbitals"]._xgrid
-        GS = staticKS.GramSchmidt(input_SCF["orbitals"].eigfuncs, xgrid)
+        GS = staticKS.GramSchmidt(input_SCF["orbitals"].eigfuncs, xgrid, "log")
         ortho = GS.make_ortho()
         if case == "self":
             norm = GS.prod_eigfuncs(ortho[0, 0, 0, 1], ortho[0, 0, 0, 1], xgrid)
@@ -99,6 +100,7 @@ class TestGS:
 
 
 if __name__ == "__main__":
+    config.grid_type = "log"
     SCF_out = TestGS._run_SCF()
     print("self_overlap_expected =", TestGS._run_overlap(SCF_out, "self"))
     print("overlap_expected =", TestGS._run_overlap(SCF_out, "other"))


### PR DESCRIPTION
Ensures a log grid is used for Kubo-Greenwood and Gram-Schmidt calculations. 

Issue #220 documents that we should extend the functionality of the sqrt grid.