### PR TITLE
Make default "grid_type" consistent and add checker

### DIFF
--- a/atoMEC/check_inputs.py
+++ b/atoMEC/check_inputs.py
@@ -912,6 +912,30 @@ class EnergyCalcs:
 
         return band_params
 
+    @staticmethod
+    def check_grid_type(grid_type):
+        r"""Check grid type.
+
+        Parameters
+        ----------
+        grid_type : str
+            the grid type
+
+        Returns
+        -------
+        grid_type : str
+            the grid type
+
+        Raises
+        ------
+        InputError.grid_type_error
+            if grid type not one of "log" or "sqrt"
+        """
+        if grid_type not in ["log", "sqrt"]:
+            raise InputError.grid_error("Grid type must be either 'log' or 'sqrt'")
+        else:
+            return grid_type
+
 
 class InputError(Exception):
     """Exit atoMEC and print relevant input error message."""

--- a/atoMEC/models.py
+++ b/atoMEC/models.py
@@ -221,7 +221,7 @@ class ISModel:
         scf_params={},
         band_params={},
         force_bound=[],
-        grid_type="log",
+        grid_type="sqrt",
         verbosity=0,
         write_info=True,
         write_density=True,
@@ -280,6 +280,9 @@ class ISModel:
             forces the orbital with quantum numbers :math:`\sigma=0,\ l=1,\ n=0` to be
             always bound even if it has positive energy. This prevents convergence
             issues.
+        grid_type : str, optional
+            the transformed radial grid used for the KS equations.
+            can be 'sqrt' (default) or 'log'
         verbosity : int, optional
             how much information is printed at each SCF cycle.
             `verbosity=0` prints the total energy and convergence values (default).
@@ -332,7 +335,7 @@ class ISModel:
         config.conv_params = check_inputs.EnergyCalcs.check_conv_params(conv_params)
         config.scf_params = check_inputs.EnergyCalcs.check_scf_params(scf_params)
         config.band_params = check_inputs.EnergyCalcs.check_band_params(band_params)
-        config.grid_type = grid_type
+        config.grid_type = check_inputs.EnergyCalcs.check_grid_type(grid_type)
 
         # experimental change
         config.force_bound = force_bound

--- a/tests/boundary_conditions_test.py
+++ b/tests/boundary_conditions_test.py
@@ -72,6 +72,7 @@ class TestBcs:
             scf_params={"maxscf": 5, "mixfrac": 0.3},
             grid_params={"ngrid": 1000, "ngrid_coarse": 600},
             band_params={"nkpts": nkpts},
+            grid_type="log",
         )
 
         # extract the total free energy

--- a/tests/conductivity_test.py
+++ b/tests/conductivity_test.py
@@ -130,6 +130,7 @@ class TestConductivity:
             4,
             scf_params={"mixfrac": 0.3, "maxscf": 6},
             grid_params={"ngrid": 1200, "ngrid_coarse": 300},
+            grid_type="log",
         )
 
         output_dict = {"Atom": F_at, "model": model, "SCF_out": output}

--- a/tests/energy_alt_test.py
+++ b/tests/energy_alt_test.py
@@ -67,6 +67,7 @@ class TestEnergyAlt:
             5,
             scf_params={"maxscf": 6, "mixfrac": 0.3},
             grid_params={"ngrid": 1000, "ngrid_coarse": 300},
+            grid_type="log",
         )
 
         # construct the EnergyAlt object

--- a/tests/exceptions_test.py
+++ b/tests/exceptions_test.py
@@ -225,3 +225,11 @@ class TestCalcEnergy:
 
         with pytest.raises(SystemExit):
             model.CalcEnergy(3, 3, band_params=bands_input)
+
+    def test_grid_type(self):
+        """Test the grid type."""
+        atom = Atom("Al", 0.01, radius=1)
+        model = models.ISModel(atom, bc="bands", unbound="quantum")
+
+        with pytest.raises(SystemExit):
+            model.CalcEnergy(3, 3, grid_type="linear")

--- a/tests/functionals_test.py
+++ b/tests/functionals_test.py
@@ -92,6 +92,7 @@ class TestFuncs:
             scf_params={"maxscf": 5, "mixfrac": 0.3},
             grid_params={"ngrid": 1000, "ngrid_coarse": 90},
             band_params={"nkpts": 30},
+            grid_type="log",
         )
 
         # extract the total free energy

--- a/tests/gramschmidt_test.py
+++ b/tests/gramschmidt_test.py
@@ -34,7 +34,6 @@ class TestGS:
     )
     def test_overlap(self, input_SCF, case, expected):
         """Run overlap integral after orthonormalizatation."""
-        config.grid_type = "log"
         assert np.isclose(
             self._run_overlap(input_SCF, case),
             expected,
@@ -66,6 +65,7 @@ class TestGS:
             4,
             scf_params={"mixfrac": 0.3, "maxscf": 5},
             grid_params={"ngrid": 1000, "ngrid_coarse": 300},
+            grid_type="log",
         )
 
         return output
@@ -100,7 +100,6 @@ class TestGS:
 
 
 if __name__ == "__main__":
-    config.grid_type = "log"
     SCF_out = TestGS._run_SCF()
     print("self_overlap_expected =", TestGS._run_overlap(SCF_out, "self"))
     print("overlap_expected =", TestGS._run_overlap(SCF_out, "other"))

--- a/tests/localization_test.py
+++ b/tests/localization_test.py
@@ -101,6 +101,7 @@ class TestLocalization:
             2,
             scf_params={"mixfrac": 0.3, "maxscf": 50},
             grid_params={"ngrid": 1000, "ngrid_coarse": 300},
+            grid_type="log",
         )
 
         output_dict = {"Atom": Al_at, "model": model, "SCF_out": output}

--- a/tests/serial_test.py
+++ b/tests/serial_test.py
@@ -60,6 +60,7 @@ class TestSerial:
             scf_params={"maxscf": 1, "mixfrac": 0.7},
             band_params={"nkpts": 30},
             grid_params={"ngrid": ngrid, "ngrid_coarse": 300},
+            grid_type="log",
         )
 
         # extract the total free energy

--- a/tests/spin_test.py
+++ b/tests/spin_test.py
@@ -67,6 +67,7 @@ class TestSpin:
             scf_params={"maxscf": 4, "mixfrac": 0.3},
             band_params={"nkpts": 50},
             grid_params={"ngrid": 1000, "ngrid_coarse": 300},
+            grid_type="log",
         )
 
         # extract the total free energy


### PR DESCRIPTION
Previously, the default "grid_type" was inconsistent because in `CalcEnergy` it was set to "log", whereas in `config` it was set to "sqrt".

This PR fixes that issue and also checks it is one of the allowed grid types.